### PR TITLE
Dynamic allocation data placement vs pre-allocation data

### DIFF
--- a/drafts/draft-brockners-inband-oam-data.xml
+++ b/drafts/draft-brockners-inband-oam-data.xml
@@ -451,7 +451,9 @@ L2/L3 distributed scenario is currently deployed by operator.
         defined as two separate options. Any deployment MAY choose to
         configure and support one or both of the following options. An
         implementation of the transport protocol that carries these in-situ
-        OAM data MAY choose to support only one of the options.</t>
+        OAM data MAY choose to support only one of the options. In the event
+	that both options are utilized at the same time, the Incremental
+	Trace Option MUST be placed before the Pre-allocated Trace Option.</t>
 
         <t><list style="hanging">
             <t hangText="Pre-allocated Trace Option:">This trace option is


### PR DESCRIPTION
Following up from today's meeting.  Adding requirement to place dynamic allocation before pre-allocation data to preserve hardware benefits of dynamic allocation approach.