### PR TITLE
Generic timestamps, ETE short sequence number, ETE timestamps

### DIFF
--- a/drafts/draft-ietf-ippm-ioam-data.xml
+++ b/drafts/draft-ietf-ippm-ioam-data.xml
@@ -18,6 +18,7 @@
 <!ENTITY RFC7820 SYSTEM "https://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.7820.xml">
 <!ENTITY RFC7821 SYSTEM "https://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.7821.xml">
 <!ENTITY RFC8126 SYSTEM "https://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.8126.xml">
+<!ENTITY RFC5905 SYSTEM "https://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.5905.xml">
 <!ENTITY I-D.brockners-inband-oam-requirements SYSTEM "https://xml2rfc.tools.ietf.org/public/rfc/bibxml-ids/reference.I-D.brockners-inband-oam-requirements.xml">
 <!ENTITY I-D.brockners-inband-oam-transport SYSTEM "https://xml2rfc.tools.ietf.org/public/rfc/bibxml-ids/reference.I-D.brockners-inband-oam-transport.xml">
 <!ENTITY I-D.brockners-proof-of-transit SYSTEM "https://xml2rfc.tools.ietf.org/public/rfc/bibxml-ids/reference.I-D.brockners-proof-of-transit.xml">
@@ -248,7 +249,7 @@
       </address>
     </author>
 
-    <author fullname="Daniel" initials="D." surname="Bernier">
+    <author fullname="Daniel Bernier" initials="D." surname="Bernier">
       <organization abbrev="">Bell Canada</organization>
 
       <address>
@@ -266,7 +267,27 @@
       </address>
     </author>
 
-    <date day="30" month="October" year="2017"/>
+    <author fullname="John Lemon" initials="J." surname="Lemon">
+      <organization abbrev="">Broadcom</organization>
+
+      <address>
+        <postal>
+          <street>270 Innovation Drive</street>
+
+          <city>San Jose</city>
+
+          <region>CA</region>
+
+          <code>95134</code>
+
+          <country>US</country>
+        </postal>
+
+        <email>john.lemon@broadcom.com</email>
+      </address>
+    </author>
+
+    <date day="16" month="January" year="2018"/>
 
     <!-- If the month and year are both specified and are the current ones, xml2rfc will fill 
          in the current day for you. If only the current year is specified, xml2rfc will fill 
@@ -633,7 +654,7 @@ Pre-allocated Trace Option Data MUST be 4-octet aligned:
                   seconds in the node data</t>
 
                   <t hangText="Bit 3">When set indicates presence of timestamp
-                  nanoseconds in the node data.</t>
+                  subseconds in the node data.</t>
 
                   <t hangText="Bit 4">When set indicates presence of transit
                   delay in the node data.</t>
@@ -801,7 +822,7 @@ IOAM Incremental Trace Option Data MUST be 4-octet aligned:
                   seconds in the node data.</t>
 
                   <t hangText="Bit 3">When set indicates presence of timestamp
-                  nanoseconds in the node data.</t>
+                  subseconds in the node data.</t>
 
                   <t hangText="Bit 4">When set indicates presence of transit
                   delay in the node data.</t>
@@ -953,24 +974,40 @@ IOAM Incremental Trace Option Data MUST be 4-octet aligned:
               <t hangText="timestamp seconds:">4-octet unsigned integer.
               Absolute timestamp in seconds that specifies the time at which
               the packet was received by the node. The structure of this field
-              is identical to the most significant 32 bits of the 64 least
+              is defined according to either <xref target="IEEE1588v2"/>
+              or to <xref target="RFC5905"/>. For <xref target="IEEE1588v2"/>,
+              it is identical to the most significant 32 bits of the 64 least
               significant bits of the <xref target="IEEE1588v2"/> timestamp.
               This truncated field consists of a 32-bit seconds field. As
               defined in <xref target="IEEE1588v2"/>, the timestamp specifies
               the number of seconds elapsed since 1 January 1970 00:00:00
-              according to the International Atomic Time (TAI).<figure>
+              according to the International Atomic Time (TAI). For <xref
+              target="RFC5905"/>, it is identical to the seconds portion of
+              the <xref target="RFC5905"/> timestamp. As defined in <xref
+              target="RFC5905"/>, the timestamp specifies
+              the number of seconds elapsed since 1 January 1900 00:00:00.
+              <figure>
                   <artwork><![CDATA[ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                       timestamp seconds                       |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+]]></artwork>
                 </figure></t>
 
-              <t hangText="timestamp nanoseconds:">4-octet unsigned integer in
-              the range 0 to 10^9-1. This timestamp specifies the fractional
-              part of the wall clock time at which the packet was received by
-              the node in units of nanoseconds. This field is identical to the
-              32 least significant bits of the <xref target="IEEE1588v2"/>
-              timestamp. This fields allows for delay computation between any
+              <t hangText="timestamp subseconds:">4-octet unsigned integer.
+              Absolute timestamp in subseconds that specifies the time at which
+              the packet was received by the node. The structure of this field
+              is defined according to either <xref target="IEEE1588v2"/>
+              or to <xref target="RFC5905"/>. For <xref target="IEEE1588v2"/>,
+              this timestamp specifies the fractional part of the wall clock
+              time, in the range 0 to 10^9-1, at which the packet was received
+              by the node, in units of nanoseconds. This field is identical to
+              the 32 least significant bits of the <xref target="IEEE1588v2"/>
+              timestamp. For <xref target="RFC5905"/>, this timestamp
+              specifies the fractional part of the wall clock time at which the
+              packet was received, in fractions of a second. This format is
+              identical to the 32 least significant bits of the <xref
+              target="RFC5905"/> timestamp.
+              This fields allows for delay computation between any
               two nodes in the network when the nodes are time synchronized.
               When this field is part of the data field but a node populating
               the field is not able to fill it, the field position in the
@@ -978,7 +1015,7 @@ IOAM Incremental Trace Option Data MUST be 4-octet aligned:
               populated.<figure>
                   <artwork><![CDATA[ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                       timestamp nanoseconds                   |
+|                       timestamp subseconds                    |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+]]></artwork>
                 </figure></t>
 
@@ -1155,10 +1192,11 @@ IOAM Incremental Trace Option Data MUST be 4-octet aligned:
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
     |     ingress_if_id             |         egress_if_id          |
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    |                  timestamp nanoseconds                        |
+    |                  timestamp subseconds                         |
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
     |                            app_data                           |
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
 
 ]]></artwork>
                 </figure></t>
@@ -1172,7 +1210,6 @@ IOAM Incremental Trace Option Data MUST be 4-octet aligned:
     |     ingress_if_id             |         egress_if_id          |
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
    
-
 ]]></artwork>
                 </figure></t>
 
@@ -1182,7 +1219,7 @@ IOAM Incremental Trace Option Data MUST be 4-octet aligned:
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
     |   Hop_Lim     |              node_id                          |
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    |                   timestamp nanoseconds                       |
+    |                   timestamp subseconds                        |
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 
 ]]></artwork>
@@ -1206,7 +1243,7 @@ IOAM Incremental Trace Option Data MUST be 4-octet aligned:
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
     |   Hop_Lim     |              node_id                          |
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    |                    timestamp nanoseconds                      |
+    |                    timestamp subseconds                       |
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
     |                            app_data                           |
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -1220,7 +1257,7 @@ IOAM Incremental Trace Option Data MUST be 4-octet aligned:
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
     |                      timestamp seconds                        |
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    |                    timestamp nanoseconds                      |
+    |                    timestamp subseconds                       |
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
     |   Length      |                     Schema Id                 |
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -1352,11 +1389,32 @@ IOAM proof of transit option data MUST be 4-octet aligned:
 ]]></artwork>
           </figure><list style="hanging">
             <t hangText="IOAM-E2E-Type:">8-bit identifier of a particular in
-            situ OAM E2E variant.<list style="empty">
-                <t>0: E2E option data is a 64-bit sequence number added to a
-                specific tube which is used to identify packet loss and
-                reordering for that tube.</t>
-              </list></t>
+            situ OAM E2E variant.<list hangIndent="9"
+            style="hanging">
+              <t hangText="Bit 0">(Most significant bit) When set indicates
+              presence of a 64-bit sequence number added to a specific tube
+              which is used to identify packet loss and reordering for that
+              tube.</t>
+
+              <t hangText="Bit 1">When set indicates presence of a 32-bit
+              sequence number added to a specific tube which is used to identify
+              packet loss and reordering for that tube.</t>
+
+              <t hangText="Bit 2">When set indicates presence of timestamp
+              seconds for the transmission of the frame. This specifies either
+              the number of seconds elapsed since 1 January 1970 00:00:00,
+              as defined in <xref target="IEEE1588v2"/>, or the number
+              of seconds elapsed since 1 January 1900 00:00:00, as defined in
+              <xref target="RFC5905"/>.</t>
+
+              <t hangText="Bit 3">When set indicates presence of timestamp
+              subseconds for the transmission of the frame. This specifies
+              either the nanoseconds portion of the timestamp for the
+              transmission of the frame, as defined in <xref
+              target="IEEE1588v2"/>, or the fractional seconds portion of
+              the timestamp for the transmission of the frame, as defined in
+              <xref target="RFC5905"/>.</t>
+            </list></t>
           </list></t>
       </section>
     </section>
@@ -1428,10 +1486,10 @@ IOAM proof of transit option data MUST be 4-octet aligned:
 
       <section title="IOAM E2E Type Registry">
         <t>This registry defines 256 code points to define IOAM-E2E-Type for
-        IOAM E2E option <xref target="IOAM_edge_to_edge_opt"/>. The code point
-        value 0 is defined in this document, 1 - 255 are available for
-        assignments via RFC Required process as per <xref
-        target="RFC8126"/>.</t>
+        IOAM E2E option <xref target="IOAM_edge_to_edge_opt"/>.
+        The meaning of Bit 0 - 3 are defined in this document. The meaning of
+        Bit 4 - 7 are available for assignments via RFC Required process as per
+        <xref target="RFC8126"/>.</t>
       </section>
     </section>
 
@@ -1482,6 +1540,8 @@ IOAM proof of transit option data MUST be 4-octet aligned:
 
     <references title="Normative References">
       &RFC2119;
+
+      &RFC5905;
 
       &RFC8126;
 


### PR DESCRIPTION
Significant changes:
Genericized timestamps, added ETE short sequence number, added ETE timestamps.

Minor changes:
Updated date. Corrected Daniel Bernier's name, added John Lemon as co-author, added reference citations for RFC 5905 (NTP).