### PR TITLE
Uniform subtype header

### DIFF
--- a/drafts/draft-ietf-ippm-ioam-data.xml
+++ b/drafts/draft-ietf-ippm-ioam-data.xml
@@ -1185,13 +1185,51 @@ IOAM proof of transit option header:
  0                   1                   2                   3
  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|IOAM POT Type|P|             Reserved                          | 
+|IOAM POT Type  | IOAM POT flags|           Reserved            | 
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 
-IOAM proof of transit option data MUST be 4-octet aligned:
+IOAM proof of transit option data MUST be 4-octet aligned.:
+    
+  0                   1                   2                   3
+  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+ +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ |       POT Option data field determined by IOAM-POT-Type       ~
+ +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 
+
+]]></artwork>
+          </figure><list style="hanging">
+            <t hangText="IOAM POT Type:">8-bit identifier of a particular POT
+            variant that dictates the POT data that is included. This document
+            defines POT Type 0:<list style="hanging">
+                <t hangText="0:">POT data is a 16 Octet field as described
+                below.</t>
+              </list></t>
+
+            <t hangText="IOAM POT flags:">8-bit. Following flags are
+            defined:<list style="hanging">
+                <t hangText="Bit 0">"Profile-to-use" (P-bit) (most significant
+                bit). Indicates which POT-profile is used by POT Type 0.</t>
+
+                <t hangText="Bit 1-7">Reserved: Must be zero.</t>
+              </list></t>
+
+            <t hangText="Reserved:">16-bit Reserved bits are present for
+            future use. The reserved bits MUST be set to 0x0.</t>
+
+            <t hangText="POT Option data:">Variable-length field. The type of
+            which is determined by the IOAM-POT-Type.</t>
+          </list></t>
+
+        <section title="IOAM Proof of Transit Type 0">
+          <t><figure>
+              <artwork><![CDATA[ 
+IOAM proof of transit option of IOAM POT Type 0:
+ 
  0                   1                   2                   3
  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|IOAM POT Type=0|P|IOAM POTFlags|           Reserved            | 
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+<-+
 |                           Random                              |  |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+  P
@@ -1204,34 +1242,38 @@ IOAM proof of transit option data MUST be 4-octet aligned:
 
 
 ]]></artwork>
-          </figure><list style="hanging">
-            <t hangText="IOAM POT Type:">7-bit identifier of a particular POT
-            variant that dictates the POT data that is included. This document
-            defines POT Type 0:<list style="hanging">
-                <t hangText="0:">POT data is a 16 Octet field as described
-                below.</t>
-              </list></t>
+            </figure><list style="hanging">
+              <t hangText="IOAM POT Type:">8-bit identifier of a particular
+              POT variant that dictates the POT data that is included, to be
+              set to 0 for the POT defined in this section.</t>
 
-            <t hangText="Reserved:">24-bit Reserved bits are present for
-            future use. The reserved bits MUST be set to 0x0.</t>
+              <t hangText="IOAM POT flags:">8-bit. Following flags are
+              defined:<list style="hanging">
+                  <t hangText="Bit 0">"Profile-to-use" (P-bit) (most
+                  significant bit). Indicates which POT-profile is used to
+                  generate the Cumulative. Any node participating in POT will
+                  have a maximum of 2 profiles configured that drive the
+                  computation of cumulative. The two profiles are numbered 0,
+                  1. This bit conveys whether profile 0 or profile 1 is used
+                  to compute the Cumulative. </t>
 
-            <t hangText="Profile to use (P):">1-bit. Indicates which
-            POT-profile is used to generate the Cumulative. Any node
-            participating in POT will have a maximum of 2 profiles configured
-            that drive the computation of cumulative. The two profiles are
-            numbered 0, 1. This bit conveys whether profile 0 or profile 1 is
-            used to compute the Cumulative.</t>
+                  <t hangText="Bit 1-7">Reserved: Must be zero.</t>
+                </list></t>
 
-            <t hangText="Random:">64-bit Per packet Random number.</t>
+              <t hangText="Reserved:">16-bit Reserved bits are present for
+              future use. The reserved bits MUST be set to 0x0.</t>
 
-            <t hangText="Cumulative:">64-bit Cumulative that is updated at
-            specific nodes by processing per packet Random number field and
-            configured parameters.</t>
-          </list>Note: Larger or smaller sizes of "Random" and "Cumulative"
-        data are feasible and could be required for certain deployments (e.g.
-        in case of space constraints in the transport protocol used). Future
-        versions of this document will address different sizes of data for
-        "proof of transit".</t>
+              <t hangText="Random:">64-bit Per packet Random number.</t>
+
+              <t hangText="Cumulative:">64-bit Cumulative that is updated at
+              specific nodes by processing per packet Random number field and
+              configured parameters.</t>
+            </list>Note: Larger or smaller sizes of "Random" and "Cumulative"
+          data are feasible and could be required for certain deployments
+          (e.g. in case of space constraints in the transport protocol used).
+          Future versions of this document will address different sizes of
+          data for "proof of transit".</t>
+        </section>
       </section>
 
       <section anchor="IOAM_edge_to_edge_opt" title="IOAM Edge-to-Edge Option">
@@ -1320,6 +1362,9 @@ IOAM proof of transit option data MUST be 4-octet aligned:
 
             <t hangText="Reserved:">16-bits Reserved bits are present for
             future use. The reserved bits MUST be set to 0x0.</t>
+
+            <t hangText="E2E Option data:">Variable-length field. The type of
+            which is determined by the IOAM-E2E-Type.</t>
           </list></t>
       </section>
     </section>
@@ -1444,8 +1489,8 @@ IOAM proof of transit option data MUST be 4-octet aligned:
             <t>The resolution is 2^(-32) seconds.</t>
           </list></t>
 
-          <t>Wraparound: <list hangIndent="10" style="empty">
-	    <t>This time format wraps around every 2^32 seconds, which is
+        <t>Wraparound: <list hangIndent="10" style="empty">
+            <t>This time format wraps around every 2^32 seconds, which is
             roughly 136 years. The next wraparound will occur in the year
             2036.</t>
           </list></t>
@@ -1563,6 +1608,8 @@ IOAM proof of transit option data MUST be 4-octet aligned:
 
             <t>IOAM POT Type</t>
 
+            <t>IOAM POT flags</t>
+
             <t>IOAM E2E Type</t>
           </list>will contain the current set of possibilities defined in this
         document. New registries in this name space are created via RFC
@@ -1573,7 +1620,7 @@ IOAM proof of transit option data MUST be 4-octet aligned:
       </section>
 
       <section title="IOAM Type Registry">
-        <t>This registry defines 256 code points to define IOAM-Type field for
+        <t>This registry defines 128 code points to define IOAM-Type field for
         identifying IOAM options as explained in <xref
         target="IOAM_option_format"></xref>. The following code points are
         defined in this draft:</t>
@@ -1586,7 +1633,7 @@ IOAM proof of transit option data MUST be 4-octet aligned:
             <t hangText="2">IOAM POT Option Type</t>
 
             <t hangText="3">IOAM E2E Option Type</t>
-          </list>4 - 255 are available for assignment via RFC Required process
+          </list>4 - 127 are available for assignment via RFC Required process
         as per <xref target="RFC8126"></xref>.</t>
       </section>
 
@@ -1612,11 +1659,21 @@ IOAM proof of transit option data MUST be 4-octet aligned:
       </section>
 
       <section title="IOAM POT Type Registry">
-        <t>This registry defines 128 code points to define IOAM POT Type for
+        <t>This registry defines 256 code points to define IOAM POT Type for
         IOAM proof of transit option <xref
         target="IOAM_proof_of_transit_option"></xref>. The code point value 0
-        is defined in this document, 1 - 127 are available for assignment via
+        is defined in this document, 1 - 255 are available for assignment via
         RFC Required process as per <xref target="RFC8126"></xref>.</t>
+      </section>
+
+      <section title="IOAM POT Flags Registry">
+        <t>This registry defines code point for each bit in the 8 bit flags
+        for IOAM POT option defined in <xref
+        target="IOAM_proof_of_transit_option"></xref>. The meaning of Bit 0
+        for IOAM POT flags is defined in this document in <xref
+        target="IOAM_proof_of_transit_option"></xref>. The meaning for Bit 1 -
+        7 are available for assignment via RFC Required process as per <xref
+        target="RFC8126"></xref>.</t>
       </section>
 
       <section title="IOAM E2E Type Registry">

--- a/drafts/draft-ietf-ippm-ioam-data.xml
+++ b/drafts/draft-ietf-ippm-ioam-data.xml
@@ -1229,7 +1229,7 @@ IOAM proof of transit option of IOAM POT Type 0:
  0                   1                   2                   3
  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|IOAM POT Type=0|P|IOAM POTFlags|           Reserved            | 
+|IOAM POT Type=0|P|R R R R R R R|           Reserved            | 
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+<-+
 |                           Random                              |  |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+  P
@@ -1247,18 +1247,16 @@ IOAM proof of transit option of IOAM POT Type 0:
               POT variant that dictates the POT data that is included, to be
               set to 0 for the POT defined in this section.</t>
 
-              <t hangText="IOAM POT flags:">8-bit. Following flags are
-              defined:<list style="hanging">
-                  <t hangText="Bit 0">"Profile-to-use" (P-bit) (most
-                  significant bit). Indicates which POT-profile is used to
-                  generate the Cumulative. Any node participating in POT will
-                  have a maximum of 2 profiles configured that drive the
-                  computation of cumulative. The two profiles are numbered 0,
-                  1. This bit conveys whether profile 0 or profile 1 is used
-                  to compute the Cumulative. </t>
+              <t hangText="P bit:">1-bit. "Profile-to-use" (P-bit) (most
+              significant bit). Indicates which POT-profile is used to
+              generate the Cumulative. Any node participating in POT will have
+              a maximum of 2 profiles configured that drive the computation of
+              cumulative. The two profiles are numbered 0, 1. This bit conveys
+              whether profile 0 or profile 1 is used to compute the
+              Cumulative.</t>
 
-                  <t hangText="Bit 1-7">Reserved: Must be zero.</t>
-                </list></t>
+              <t hangText="R (7 bits):">7-bit IOAM POT flags for future use.
+              MUST be zero on transmission and ignored on receipt. </t>
 
               <t hangText="Reserved:">16-bit Reserved bits are present for
               future use. The reserved bits MUST be set to 0x0.</t>
@@ -1357,7 +1355,7 @@ IOAM proof of transit option of IOAM POT Type 0:
                 in order to detect the error indication.</t>
 
                 <t hangText="Bit 4-15">Undefined. An IOAM encapsulating node
-                must set the value of each of these bits to 0. </t>
+                must set the value of each of these bits to 0.</t>
               </list></t>
 
             <t hangText="Reserved:">16-bits Reserved bits are present for

--- a/drafts/draft-ietf-ippm-ioam-data.xml
+++ b/drafts/draft-ietf-ippm-ioam-data.xml
@@ -201,13 +201,13 @@
 
       <address>
         <postal>
-          <street/>
+          <street></street>
 
-          <city/>
+          <city></city>
 
-          <code/>
+          <code></code>
 
-          <country/>
+          <country></country>
         </postal>
 
         <email>davidm@mellanox.com</email>
@@ -246,7 +246,7 @@
           <country>US</country>
         </postal>
 
-        <email/>
+        <email></email>
       </address>
     </author>
 
@@ -255,13 +255,13 @@
 
       <address>
         <postal>
-          <street/>
+          <street></street>
 
-          <city/>
+          <city></city>
 
-          <code/>
+          <code></code>
 
-          <country/>
+          <country></country>
         </postal>
 
         <email>daniel.bernier@bell.ca</email>
@@ -288,7 +288,7 @@
       </address>
     </author>
 
-    <date day="28" month="February" year="2018"/>
+    <date day="28" month="February" year="2018" />
 
     <!-- If the month and year are both specified and are the current ones, xml2rfc will fill 
          in the current day for you. If only the current year is specified, xml2rfc will fill 
@@ -338,17 +338,17 @@
       is added to the data packets rather than is being sent within packets
       specifically dedicated to OAM. A discussion of the motivation and
       requirements for in-situ OAM can be found in <xref
-      target="I-D.brockners-inband-oam-requirements"/>. IOAM is to complement
-      mechanisms such as Ping or Traceroute, or more recent active probing
-      mechanisms as described in <xref
-      target="I-D.lapukhov-dataplane-probe"/>. In terms of "active" or
+      target="I-D.brockners-inband-oam-requirements"></xref>. IOAM is to
+      complement mechanisms such as Ping or Traceroute, or more recent active
+      probing mechanisms as described in <xref
+      target="I-D.lapukhov-dataplane-probe"></xref>. In terms of "active" or
       "passive" OAM, "in-situ" OAM can be considered a hybrid OAM type. While
       no extra packets are sent, IOAM adds information to the packets
       therefore cannot be considered passive. In terms of the classification
-      given in <xref target="RFC7799"/> IOAM could be portrayed as Hybrid Type
-      1. "In-situ" mechanisms do not require extra packets to be sent and
-      hence don't change the packet traffic mix within the network. IOAM
-      mechanisms can be leveraged where mechanisms using e.g. ICMP do not
+      given in <xref target="RFC7799"></xref> IOAM could be portrayed as
+      Hybrid Type 1. "In-situ" mechanisms do not require extra packets to be
+      sent and hence don't change the packet traffic mix within the network.
+      IOAM mechanisms can be leveraged where mechanisms using e.g. ICMP do not
       apply or do not offer the desired results, such as proving that a
       certain traffic flow takes a pre-defined path, SLA verification for the
       live data traffic, detailed statistics on traffic distribution paths in
@@ -361,7 +361,7 @@
       <t>The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
       "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
       document are to be interpreted as described in <xref
-      target="RFC2119"/>.</t>
+      target="RFC2119"></xref>.</t>
 
       <t>Abbreviations used in this document:</t>
 
@@ -369,7 +369,7 @@
           <t hangText="E2E">Edge to Edge</t>
 
           <t hangText="Geneve:">Generic Network Virtualization Encapsulation
-          <xref target="I-D.ietf-nvo3-geneve"/></t>
+          <xref target="I-D.ietf-nvo3-geneve"></xref></t>
 
           <t hangText="IOAM:">In-situ Operations, Administration, and
           Maintenance</t>
@@ -377,7 +377,7 @@
           <t hangText="MTU:">Maximum Transmit Unit</t>
 
           <t hangText="NSH:">Network Service Header <xref
-          target="I-D.ietf-sfc-nsh"/></t>
+          target="I-D.ietf-sfc-nsh"></xref></t>
 
           <t hangText="OAM:">Operations, Administration, and Maintenance</t>
 
@@ -391,7 +391,7 @@
 
           <t hangText="VXLAN-GPE:">Virtual eXtensible Local Area Network,
           Generic Protocol Extension <xref
-          target="I-D.ietf-nvo3-vxlan-gpe"/></t>
+          target="I-D.ietf-nvo3-vxlan-gpe"></xref></t>
         </list></t>
     </section>
 
@@ -465,16 +465,29 @@
       data types required for IOAM. The different uses of IOAM require the
       definition of different types of data. The IOAM data fields for the data
       being carried corresponds to the three main categories of IOAM data
-      defined in <xref target="I-D.brockners-inband-oam-requirements"/>, which
-      are: edge-to-edge, per node, and for selected nodes only.</t>
+      defined in <xref target="I-D.brockners-inband-oam-requirements"></xref>,
+      which are: edge-to-edge, per node, and for selected nodes only.</t>
 
-      <t>Transport options for IOAM data are outside the scope of this memo,
-      and are discussed in <xref
-      target="I-D.brockners-inband-oam-transport"/>. IOAM data fields are
-      fixed length data fields. A bit field determines the set of OAM data
-      fields embedded in a packet. Depending on the type of the encapsulation,
-      a counter field indicates how many data fields are included in a
-      particular packet.</t>
+      <t>Encapsulation options for IOAM data are outside the scope of this
+      memo, and are discussed in <xref
+      target="I-D.brockners-inband-oam-transport"></xref>. A bit field
+      determines the set of OAM data fields embedded in a packet. Depending on
+      the type of the encapsulation, a type and length field indicates type
+      and length of the data fields that are included in a particular packet.
+      For the encapsulations where IOAM uses its own name space to distinguish
+      between the various data type options defined in this section, IOAM-Type
+      registry is defined with the following code points to identify the IOAM
+      options:</t>
+
+      <t><list style="hanging">
+          <t hangText="0">IOAM Pre-allocated Trace Option Type</t>
+
+          <t hangText="1">IOAM Incremental Trace Option Type</t>
+
+          <t hangText="2">IOAM POT Option Type</t>
+
+          <t hangText="3">IOAM E2E Option Type</t>
+        </list></t>
 
       <t>IOAM is expected to be deployed in a specific domain rather than on
       the overall Internet. The part of the network which employs IOAM is
@@ -645,9 +658,9 @@ The trace option data MUST be 4-octet aligned:
               <t hangText=" ">The IOAM-Trace-Type value is a bit field. The
               following bit fields are defined in this document, with details
               on each field described in the <xref
-              target="trace-node-data-element"/>. The order of packing the
-              data fields in each node data element follows the bit order of
-              the IOAM-Trace-Type field, as follows:<list hangIndent="9"
+              target="trace-node-data-element"></xref>. The order of packing
+              the data fields in each node data element follows the bit order
+              of the IOAM-Trace-Type field, as follows:<list hangIndent="9"
                   style="hanging">
                   <t hangText="Bit 0">(Most significant bit) When set
                   indicates presence of Hop_Lim and node_id in the node
@@ -688,22 +701,22 @@ The trace option data MUST be 4-octet aligned:
                   <t hangText="Bit 11">When set indicates presence of the
                   Checksum Complement node data.</t>
 
-                  <t hangText="Bit 12-15">Undefined. An IOAM encapsulating node
-                  must set the value of each of these bits to 0. If an IOAM
-                  transit node receives a packet with one or more of these bits
-                  set to 1, it must either:
-                  <list style="numbers">
-                    <t>Add corresponding node data filled with the reserved
-                    value 0xFFFFFFFF, after the node data fields for the
-                    IOAM-Trace-Type bits defined above, such that the total
-                    node data added by this node in units of 4-octets is equal
-                    to NodeLen, or</t>
-                    <t>Not add any node data fields to the packet, even for the
-                    IOAM-Trace-Type bits defined above.</t>
-                  </list></t>
+                  <t hangText="Bit 12-15">Undefined. An IOAM encapsulating
+                  node must set the value of each of these bits to 0. If an
+                  IOAM transit node receives a packet with one or more of
+                  these bits set to 1, it must either: <list style="numbers">
+                      <t>Add corresponding node data filled with the reserved
+                      value 0xFFFFFFFF, after the node data fields for the
+                      IOAM-Trace-Type bits defined above, such that the total
+                      node data added by this node in units of 4-octets is
+                      equal to NodeLen, or</t>
+
+                      <t>Not add any node data fields to the packet, even for
+                      the IOAM-Trace-Type bits defined above.</t>
+                    </list></t>
                 </list></t>
 
-              <t hangText=" "><xref target="trace-node-data-element"/>
+              <t hangText=" "><xref target="trace-node-data-element"></xref>
               describes the IOAM data types and their formats. Within an
               in-situ OAM domain possible combinations of these bits making
               the IOAM-Trace-Type can be restricted by configuration
@@ -712,15 +725,15 @@ The trace option data MUST be 4-octet aligned:
               <t hangText="NodeLen:">5-bit unsigned integer. This field
               specifies the length of data added by each node in multiples of
               4-octets, excluding the length of the "Opaque State Snapshot"
-              field. <vspace blankLines="1"/> If IOAM-Trace-Type bit 7 is not
+              field. <vspace blankLines="1" /> If IOAM-Trace-Type bit 7 is not
               set, then NodeLen specifies the actual length added by each
               node. If IOAM-Trace-Type bit 7 is set, then the actual length
               added by a node would be (NodeLen + Opaque Data Length). <vspace
-              blankLines="1"/> For example, if 3 IOAM-Trace-Type bits are set
+              blankLines="1" /> For example, if 3 IOAM-Trace-Type bits are set
               and none of them are wide, then NodeLen would be 3. If 3
               IOAM-Trace-Type bits are set and 2 of them are wide, then
-              NodeLen would be 5. <vspace blankLines="1"/> An IOAM
-              encapsulating node must set NodeLen. <vspace blankLines="1"/> A
+              NodeLen would be 5. <vspace blankLines="1" /> An IOAM
+              encapsulating node must set NodeLen. <vspace blankLines="1" /> A
               node receiving an IOAM Pre-allocated or Incremental Trace Option
               may rely on the NodeLen value, or it may ignore the NodeLen
               value and calculate the node length from the IOAM-Trace-Type
@@ -794,10 +807,10 @@ The trace option data MUST be 4-octet aligned:
                  title="IOAM node data fields and associated formats">
           <t>All the data fields MUST be 4-octet aligned. If a node which is
           supposed to update an IOAM data field is not capable of populating
-          the value of a field set in the IOAM-Trace-Type, the field value MUST
-          be set to 0xFFFFFFFF for 4-octet fields or 0xFFFFFFFFFFFFFFFF for
-          8-octet fields, indicating that the value is not populated, except
-          when explicitly specified in the field description below.</t>
+          the value of a field set in the IOAM-Trace-Type, the field value
+          MUST be set to 0xFFFFFFFF for 4-octet fields or 0xFFFFFFFFFFFFFFFF
+          for 8-octet fields, indicating that the value is not populated,
+          except when explicitly specified in the field description below.</t>
 
           <t>Data field and associated data type for each of the data field is
           shown below:</t>
@@ -845,35 +858,35 @@ The trace option data MUST be 4-octet aligned:
 
               <t hangText="timestamp seconds:">4-octet unsigned integer.
               Absolute timestamp in seconds that specifies the time at which
-              the packet was received by the node. This field has three possible
-			  formats; based on either PTP <xref target="IEEE1588v2"/>,
-              NTP <xref target="RFC5905"/>, or POSIX <xref target="POSIX"/>. 
-			  The three timestamp formats are specified in 
-			  <xref target="TimestampSec"/>. In all three cases, the Timestamp 
-			  Seconds field contains the 32 most significant bits of the 
-			  timestamp format that is specified in 
-			  <xref target="TimestampSec"/>. If a node is not capable of 
-			  populating this field, it assigns the value 0xFFFFFFFF. Note that
-			  this is a legitimate value that is valid for 1 second in 
-			  approximately 136 years; the analyzer should correlate several
-			  packets or compare the timestamp value to its own time-of-day 
-			  in order to detect the error indication.</t>
+              the packet was received by the node. This field has three
+              possible formats; based on either PTP <xref
+              target="IEEE1588v2"></xref>, NTP <xref target="RFC5905"></xref>,
+              or POSIX <xref target="POSIX"></xref>. The three timestamp
+              formats are specified in <xref target="TimestampSec"></xref>. In
+              all three cases, the Timestamp Seconds field contains the 32
+              most significant bits of the timestamp format that is specified
+              in <xref target="TimestampSec"></xref>. If a node is not capable
+              of populating this field, it assigns the value 0xFFFFFFFF. Note
+              that this is a legitimate value that is valid for 1 second in
+              approximately 136 years; the analyzer should correlate several
+              packets or compare the timestamp value to its own time-of-day in
+              order to detect the error indication.</t>
 
               <t hangText="timestamp subseconds:">4-octet unsigned integer.
               Absolute timestamp in subseconds that specifies the time at
-              which the packet was received by the node. This field has three possible
-			  formats; based on either PTP <xref target="IEEE1588v2"/>,
-              NTP <xref target="RFC5905"/>, or POSIX <xref target="POSIX"/>. 
-			  The three timestamp formats are specified in 
-			  <xref target="TimestampSec"/>. In all three cases, the Timestamp 
-			  Subseconds field contains the 32 least significant bits of the 
-			  timestamp format that is specified in 
-			  <xref target="TimestampSec"/>. If a node is not capable of 
-			  populating this field, it assigns the value 0xFFFFFFFF. Note that
-			  this is a legitimate value in the NTP format, valid for 
-			  approximately 233 picoseconds in every second. If the NTP format 
-			  is used the analyzer should correlate several packets in order to 
-			  detect the error indication.</t>
+              which the packet was received by the node. This field has three
+              possible formats; based on either PTP <xref
+              target="IEEE1588v2"></xref>, NTP <xref target="RFC5905"></xref>,
+              or POSIX <xref target="POSIX"></xref>. The three timestamp
+              formats are specified in <xref target="TimestampSec"></xref>. In
+              all three cases, the Timestamp Subseconds field contains the 32
+              least significant bits of the timestamp format that is specified
+              in <xref target="TimestampSec"></xref>. If a node is not capable
+              of populating this field, it assigns the value 0xFFFFFFFF. Note
+              that this is a legitimate value in the NTP format, valid for
+              approximately 233 picoseconds in every second. If the NTP format
+              is used the analyzer should correlate several packets in order
+              to detect the error indication.</t>
 
               <t hangText="transit delay:">4-octet unsigned integer in the
               range 0 to 2^31-1. It is the time in nanoseconds the packet
@@ -943,12 +956,10 @@ The trace option data MUST be 4-octet aligned:
                   <t hangText="Opaque data:">Variable length field. This field
                   is interpreted as specified by the schema identified by the
                   Schema ID.</t>
-                </list>
-
-                When this field is part of the data field but a node populating
-                the field has no opaque state data to report, the Length must
-                be set to 0 and the Schema ID must be set to 0xFFFFFF to mean
-                no schema.</t>
+                </list> When this field is part of the data field but a node
+              populating the field has no opaque state data to report, the
+              Length must be set to 0 and the Schema ID must be set to
+              0xFFFFFF to mean no schema.</t>
 
               <t hangText="Hop_Lim and node_id wide:">8-octet field defined as
               follows: <figure>
@@ -1015,22 +1026,21 @@ The trace option data MUST be 4-octet aligned:
               Checksum field. When the Checksum Complement is present, an IOAM
               encapsulating node or IOAM transit node adding node data MUST
               carry out one of the following two alternatives in order to
-              maintain the correctness of the UDP Checksum value:
-              <list style="numbers">
-                <t>Recompute the UDP Checksum field.</t>
-                <t>Use the Checksum Complement to make a checksum-neutral
-                update in the UDP payload; the Checksum Complement is assigned
-                a value that complements the rest of the node data fields that
-                were added by the current node, causing the existing UDP
-                Checksum field to remain correct.</t>
-              </list>
-              IOAM decapsulating nodes MUST recompute the UDP Checksum field,
-              since they do not know whether previous hops modified the UDP
-              Checksum field or the Checksum Complement field.
-              <vspace blankLines="1" />
-              Checksum Complement fields are used in a similar manner in
-              <xref target="RFC7820"/> and <xref target="RFC7821"/>.
-              <figure>
+              maintain the correctness of the UDP Checksum value: <list
+                  style="numbers">
+                  <t>Recompute the UDP Checksum field.</t>
+
+                  <t>Use the Checksum Complement to make a checksum-neutral
+                  update in the UDP payload; the Checksum Complement is
+                  assigned a value that complements the rest of the node data
+                  fields that were added by the current node, causing the
+                  existing UDP Checksum field to remain correct.</t>
+                </list> IOAM decapsulating nodes MUST recompute the UDP
+              Checksum field, since they do not know whether previous hops
+              modified the UDP Checksum field or the Checksum Complement
+              field. <vspace blankLines="1" /> Checksum Complement fields are
+              used in a similar manner in <xref target="RFC7820"></xref> and
+              <xref target="RFC7821"></xref>. <figure>
                   <artwork><![CDATA[ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |      Checksum Complement      |           Reserved            |
@@ -1147,7 +1157,7 @@ The trace option data MUST be 4-octet aligned:
       <section anchor="IOAM_proof_of_transit_option"
                title="IOAM Proof of Transit Option">
         <t>IOAM Proof of Transit data is to support the path or service
-        function chain <xref target="RFC7665"/> verification use cases.
+        function chain <xref target="RFC7665"></xref> verification use cases.
         Proof-of-transit uses methods like nested hashing or nested encryption
         of the IOAM data or mechanisms such as Shamir's Secret Sharing Schema
         (SSSS). While details on how the IOAM data for the proof of transit
@@ -1172,10 +1182,11 @@ IOAM proof of transit option:
 
 IOAM proof of transit option header:
  
- 0 1 2 3 4 5 6 7 
-+-+-+-+-+-+-+-+-+
-|IOAM POT Type|P|  
-+-+-+-+-+-+-+-+-+
+ 0                   1                   2                   3
+ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|IOAM POT Type|P|             Reserved                          | 
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 
 IOAM proof of transit option data MUST be 4-octet aligned:
 
@@ -1200,6 +1211,9 @@ IOAM proof of transit option data MUST be 4-octet aligned:
                 <t hangText="0:">POT data is a 16 Octet field as described
                 below.</t>
               </list></t>
+
+            <t hangText="Reserved:">24-bit Reserved bits are present for
+            future use. The reserved bits MUST be set to 0x0.</t>
 
             <t hangText="Profile to use (P):">1-bit. Indicates which
             POT-profile is used to generate the Cumulative. Any node
@@ -1229,7 +1243,7 @@ IOAM proof of transit option data MUST be 4-octet aligned:
         In order to detect packet loss, packet reordering, or packet
         duplication in an in-situ OAM-domain, sequence numbers can be added to
         packets of a particular tube (see <xref
-        target="I-D.hildebrand-spud-prototype"/>). Each tube leverages a
+        target="I-D.hildebrand-spud-prototype"></xref>). Each tube leverages a
         dedicated namespace for its sequence numbers.</t>
 
         <t><figure>
@@ -1238,10 +1252,11 @@ IOAM proof of transit option data MUST be 4-octet aligned:
 
    IOAM edge-to-edge option header:
    
-    0 1 2 3 4 5 6 7 
-   +-+-+-+-+-+-+-+-+
-   | IOAM-E2E-Type |
-   +-+-+-+-+-+-+-+-+
+   0                   1                   2                   3
+   0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |         IOAM-E2E-Type         |             Reserved          |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 
    IOAM edge-to-edge option data MUST be 4-octet aligned:
 
@@ -1253,8 +1268,10 @@ IOAM proof of transit option data MUST be 4-octet aligned:
 
 ]]></artwork>
           </figure><list style="hanging">
-            <t hangText="IOAM-E2E-Type:">8-bit identifier of a particular in
-            situ OAM E2E variant.<list hangIndent="9" style="hanging">
+            <t hangText="IOAM-E2E-Type:">16-bit identifier of a particular in
+            situ OAM E2E variant. The order of packing the E2E option data
+            field elements follows the bit order of the IOAM-E2E-Type field,
+            as follows:<list hangIndent="9" style="hanging">
                 <t hangText="Bit 0">(Most significant bit) When set indicates
                 presence of a 64-bit sequence number added to a specific tube
                 which is used to identify packet loss and reordering for that
@@ -1265,58 +1282,66 @@ IOAM proof of transit option data MUST be 4-octet aligned:
                 identify packet loss and reordering for that tube.</t>
 
                 <t hangText="Bit 2">When set indicates presence of timestamp
-                seconds for the transmission of the frame. This 4-octet field 
-				has three possible formats; based on either PTP 
-				<xref target="IEEE1588v2"/>, NTP <xref target="RFC5905"/>, or 
-				POSIX <xref target="POSIX"/>. The three timestamp formats are 
-				specified in <xref target="TimestampSec"/>. In all three cases, 
-				the Timestamp Seconds field contains the 32 most significant 
-				bits of the timestamp format that is specified in
-				<xref target="TimestampSec"/>. If a node is not capable of
-				populating this field, it assigns the value 0xFFFFFFFF. Note that
-				this is a legitimate value that is valid for 1 second in
-				approximately 136 years; the analyzer should correlate several
-				packets or compare the timestamp value to its own time-of-day 
-				in order to detect the error indication.</t>
+                seconds for the transmission of the frame. This 4-octet field
+                has three possible formats; based on either PTP <xref
+                target="IEEE1588v2"></xref>, NTP <xref
+                target="RFC5905"></xref>, or POSIX <xref
+                target="POSIX"></xref>. The three timestamp formats are
+                specified in <xref target="TimestampSec"></xref>. In all three
+                cases, the Timestamp Seconds field contains the 32 most
+                significant bits of the timestamp format that is specified in
+                <xref target="TimestampSec"></xref>. If a node is not capable
+                of populating this field, it assigns the value 0xFFFFFFFF.
+                Note that this is a legitimate value that is valid for 1
+                second in approximately 136 years; the analyzer should
+                correlate several packets or compare the timestamp value to
+                its own time-of-day in order to detect the error
+                indication.</t>
 
                 <t hangText="Bit 3">When set indicates presence of timestamp
-                subseconds for the transmission of the frame. This 4-octet field 
-				has three possible formats; based on either PTP 
-				<xref target="IEEE1588v2"/>, NTP <xref target="RFC5905"/>, or 
-				POSIX <xref target="POSIX"/>. The three timestamp formats are 
-				specified in <xref target="TimestampSec"/>. In all three cases, 
-				the Timestamp Subseconds field contains the 32 least significant 
-				bits of the timestamp format that is specified in 
-				<xref target="TimestampSec"/>. If a node is not capable of 
-				populating this field, it assigns the value 0xFFFFFFFF. Note 
-				that this is a legitimate value in the NTP format, valid for
-				approximately 233 picoseconds in every second. If the NTP format
-				is used the analyzer should correlate several packets in order 
-				to detect the error indication.</t>
+                subseconds for the transmission of the frame. This 4-octet
+                field has three possible formats; based on either PTP <xref
+                target="IEEE1588v2"></xref>, NTP <xref
+                target="RFC5905"></xref>, or POSIX <xref
+                target="POSIX"></xref>. The three timestamp formats are
+                specified in <xref target="TimestampSec"></xref>. In all three
+                cases, the Timestamp Subseconds field contains the 32 least
+                significant bits of the timestamp format that is specified in
+                <xref target="TimestampSec"></xref>. If a node is not capable
+                of populating this field, it assigns the value 0xFFFFFFFF.
+                Note that this is a legitimate value in the NTP format, valid
+                for approximately 233 picoseconds in every second. If the NTP
+                format is used the analyzer should correlate several packets
+                in order to detect the error indication.</t>
+
+                <t hangText="Bit 4-15">Undefined. An IOAM encapsulating node
+                must set the value of each of these bits to 0. </t>
               </list></t>
+
+            <t hangText="Reserved:">16-bits Reserved bits are present for
+            future use. The reserved bits MUST be set to 0x0.</t>
           </list></t>
       </section>
     </section>
 
-	<section anchor="TimestampSec" title="Timestamp Formats">
-	<t>The IOAM data fields include a timestamp field which is represented in 
-	one of three possible timestamp formats. It is assumed that the management 
-	plane is responsible for determining which timestamp format is used.</t>
-	
-	<section anchor="PTPFromatSec" title="PTP Truncated Timestamp Format">
+    <section anchor="TimestampSec" title="Timestamp Formats">
+      <t>The IOAM data fields include a timestamp field which is represented
+      in one of three possible timestamp formats. It is assumed that the
+      management plane is responsible for determining which timestamp format
+      is used.</t>
 
-	 <t>The Precision Time Protocol (PTP) <xref target="IEEE1588v2"></xref> uses 
-	 an 80-bit timestamp format. The truncated timestamp format is a 64-bit 
-	 field, which is the 64 least significant bits of the 80-bit PTP timestamp. 
-	 The PTP truncated format is specified in Section 4.3 of 
-	 <xref target="I-D.ietf-ntp-packet-timestamps"/>, and the details are 
-	 presented below for the sake of completeness.</t>
-	 
-     <figure align="center" anchor="PTPFormat" 
-	 title="PTP [IEEE1588] Truncated Timestamp Format">
+      <section anchor="PTPFromatSec" title="PTP Truncated Timestamp Format">
+        <t>The Precision Time Protocol (PTP) <xref target="IEEE1588v2"></xref>
+        uses an 80-bit timestamp format. The truncated timestamp format is a
+        64-bit field, which is the 64 least significant bits of the 80-bit PTP
+        timestamp. The PTP truncated format is specified in Section 4.3 of
+        <xref target="I-D.ietf-ntp-packet-timestamps"></xref>, and the details
+        are presented below for the sake of completeness.</t>
 
-       <artwork align="left">
-         <![CDATA[
+        <figure align="center" anchor="PTPFormat"
+                title="PTP [IEEE1588] Truncated Timestamp Format">
+          <artwork align="left"><![CDATA[
+         
      0                   1                   2                   3
      0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -1325,66 +1350,65 @@ IOAM proof of transit option data MUST be 4-octet aligned:
     |                          Nanoseconds                          |
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
            ]]></artwork>
+        </figure>
 
-     </figure>
+        <t>Timestamp field format: <list hangIndent="10" style="empty">
+            <t>Seconds: specifies the integer portion of the number of seconds
+            since the epoch.</t>
 
+            <t>+ Size: 32 bits.</t>
 
-     <t>Timestamp field format: <list
-         hangIndent="10" style="empty">
-         <t>Seconds: specifies the integer portion of the number of seconds 
-		 since the epoch.</t>
-		 <t>+ Size: 32 bits.</t>
-		 <t>+ Units: seconds.</t>
-         <t>Nanoseconds: specifies the fractional portion of the number of 
-		 seconds since the epoch.</t>
-		 <t>+ Size: 32 bits.</t>
-		 <t>+ Units: nanoseconds. The value of this field is in the range 0 to 
-		 (10^9)-1.</t>
-       </list></t>
+            <t>+ Units: seconds.</t>
 
-     <t>Epoch: <list
-         hangIndent="10" style="empty">
-         <t>The PTP <xref target="IEEE1588v2"></xref> epoch is 1 January 1970 
-		 00:00:00 TAI, which is 31 December 1969 23:59:51.999918 UTC.</t>
-       </list></t>
+            <t>Nanoseconds: specifies the fractional portion of the number of
+            seconds since the epoch.</t>
 
-     <t>Resolution: <list
-         hangIndent="10" style="empty">
-         <t>The resolution is 1 nanosecond.</t>
-       </list></t>
+            <t>+ Size: 32 bits.</t>
 
-     <t>Wraparound: <list
-         hangIndent="10" style="empty">
-         <t>This time format wraps around every 2^32 seconds, which is roughly 
-		 136 years. The next wraparound will occur in the year 2106.</t>
-       </list></t>
+            <t>+ Units: nanoseconds. The value of this field is in the range 0
+            to (10^9)-1.</t>
+          </list></t>
 
-     <t>Synchronization Aspects: <list
-         hangIndent="10" style="empty">
-		<t>It is assumed that nodes that run this protocol are synchronized 
-		among themselves. Nodes may be synchronized to a global reference time. 
-		Note that if PTP <xref target="IEEE1588v2"></xref> is used for 
-		synchronization, the timestamp may be derived from the PTP-synchronized 
-		clock, allowing the timestamp to be measured with respect to the clock 
-		of an PTP Grandmaster clock.</t>
-		 <t>The PTP truncated timestamp format is not affected by leap seconds.
-		 </t>
-       </list></t>
+        <t>Epoch: <list hangIndent="10" style="empty">
+            <t>The PTP <xref target="IEEE1588v2"></xref> epoch is 1 January
+            1970 00:00:00 TAI, which is 31 December 1969 23:59:51.999918
+            UTC.</t>
+          </list></t>
 
-	</section>
+        <t>Resolution: <list hangIndent="10" style="empty">
+            <t>The resolution is 1 nanosecond.</t>
+          </list></t>
 
-	<section anchor="NTPFormatSec" title="NTP 64-bit Timestamp Format">
+        <t>Wraparound: <list hangIndent="10" style="empty">
+            <t>This time format wraps around every 2^32 seconds, which is
+            roughly 136 years. The next wraparound will occur in the year
+            2106.</t>
+          </list></t>
 
-	 <t>The Network Time Protocol (NTP) <xref target="RFC5905"></xref> timestamp 
-	 format is 64 bits long. This format is specified in Section 4.2.1 of 
-	 <xref target="I-D.ietf-ntp-packet-timestamps"/>, and the details are 
-	 presented below for the sake of completeness.</t>
-	 
-     <figure align="center" anchor="NTPFormat" 
-	 title="NTP [RFC5905] 64-bit Timestamp Format">
+        <t>Synchronization Aspects: <list hangIndent="10" style="empty">
+            <t>It is assumed that nodes that run this protocol are
+            synchronized among themselves. Nodes may be synchronized to a
+            global reference time. Note that if PTP <xref
+            target="IEEE1588v2"></xref> is used for synchronization, the
+            timestamp may be derived from the PTP-synchronized clock, allowing
+            the timestamp to be measured with respect to the clock of an PTP
+            Grandmaster clock.</t>
 
-       <artwork align="left">
-         <![CDATA[
+            <t>The PTP truncated timestamp format is not affected by leap
+            seconds.</t>
+          </list></t>
+      </section>
+
+      <section anchor="NTPFormatSec" title="NTP 64-bit Timestamp Format">
+        <t>The Network Time Protocol (NTP) <xref target="RFC5905"></xref>
+        timestamp format is 64 bits long. This format is specified in Section
+        4.2.1 of <xref target="I-D.ietf-ntp-packet-timestamps"></xref>, and
+        the details are presented below for the sake of completeness.</t>
+
+        <figure align="center" anchor="NTPFormat"
+                title="NTP [RFC5905] 64-bit Timestamp Format">
+          <artwork align="left"><![CDATA[
+         
      0                   1                   2                   3
      0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -1393,66 +1417,63 @@ IOAM proof of transit option data MUST be 4-octet aligned:
     |                            Fraction                           |
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
            ]]></artwork>
+        </figure>
 
-     </figure>
+        <t>Timestamp field format: <list hangIndent="10" style="empty">
+            <t>Seconds: specifies the integer portion of the number of seconds
+            since the epoch.</t>
 
+            <t>+ Size: 32 bits.</t>
 
-     <t>Timestamp field format: <list
-         hangIndent="10" style="empty">
-         <t>Seconds: specifies the integer portion of the number of seconds 
-		 since the epoch.</t>
-		 <t>+ Size: 32 bits.</t>
-		 <t>+ Units: seconds.</t>
-         <t>Fraction: specifies the fractional portion of the number of seconds 
-		 since the epoch.</t>
-		 <t>+ Size: 32 bits.</t>
-		 <t>+ Units: the unit is 2^(-32) seconds, which is roughly equal to 233 
-		 picoseconds.</t>
-       </list></t>
+            <t>+ Units: seconds.</t>
 
-     <t>Epoch: <list
-         hangIndent="10" style="empty">
-         <t>The epoch is 1 January 1900 at 00:00 UTC.</t>
-       </list></t>
+            <t>Fraction: specifies the fractional portion of the number of
+            seconds since the epoch.</t>
 
-     <t>Resolution: <list
-         hangIndent="10" style="empty">
-         <t>The resolution is 2^(-32) seconds.</t>
-       </list></t>
-	   
-     <t>Wraparound: <list
-         hangIndent="10" style="empty">
-         <t>This time format wraps around every 2^32 seconds, which is roughly 
-		 136 years. The next wraparound will occur in the year 2036.</t>
-       </list></t>
+            <t>+ Size: 32 bits.</t>
 
-     <t>Synchronization Aspects: <list
-         hangIndent="10" style="empty">
-         <t>Nodes that use this timestamp format will typically be synchronized 
-		 to UTC using NTP <xref target="RFC5905"></xref>. Thus, the timestamp 
-		 may be derived from the NTP-synchronized clock, allowing the timestamp 
-		 to be measured with respect to the clock of an NTP server.</t> 
-		 <t>The NTP timestamp format is affected by leap seconds; it represents 
-		 the number of seconds since the epoch minus the number of leap seconds 
-		 that have occurred since the epoch. The value of a timestamp during or 
-		 slightly after a leap second may be temporarily inaccurate.</t>
-       </list></t>
-	   
-	</section>
+            <t>+ Units: the unit is 2^(-32) seconds, which is roughly equal to
+            233 picoseconds.</t>
+          </list></t>
 
+        <t>Epoch: <list hangIndent="10" style="empty">
+            <t>The epoch is 1 January 1900 at 00:00 UTC.</t>
+          </list></t>
 
+        <t>Resolution: <list hangIndent="10" style="empty">
+            <t>The resolution is 2^(-32) seconds.</t>
+          </list></t>
 
-	<section anchor="POSIXFormatSec" title="POSIX-based Timestamp Format">
+        <t>Wraparound: <list hangIndent="10" style="empty">
+            <t>This time format wraps around every 2^32 seconds, which is
+            roughly 136 years. The next wraparound will occur in the year
+            2036.</t>
+          </list></t>
 
-	 <t>This timestamp format is based on the POSIX time format 
-	 <xref target="POSIX"></xref>. The detailed specification of the timestamp 
-	 format used in this document is presented below.</t>
-	 
-     <figure align="center" anchor="POSIXFormat" 
-	 title="POSIX-based Timestamp Format">
+        <t>Synchronization Aspects: <list hangIndent="10" style="empty">
+            <t>Nodes that use this timestamp format will typically be
+            synchronized to UTC using NTP <xref target="RFC5905"></xref>.
+            Thus, the timestamp may be derived from the NTP-synchronized
+            clock, allowing the timestamp to be measured with respect to the
+            clock of an NTP server.</t>
 
-       <artwork align="left">
-         <![CDATA[
+            <t>The NTP timestamp format is affected by leap seconds; it
+            represents the number of seconds since the epoch minus the number
+            of leap seconds that have occurred since the epoch. The value of a
+            timestamp during or slightly after a leap second may be
+            temporarily inaccurate.</t>
+          </list></t>
+      </section>
+
+      <section anchor="POSIXFormatSec" title="POSIX-based Timestamp Format">
+        <t>This timestamp format is based on the POSIX time format <xref
+        target="POSIX"></xref>. The detailed specification of the timestamp
+        format used in this document is presented below.</t>
+
+        <figure align="center" anchor="POSIXFormat"
+                title="POSIX-based Timestamp Format">
+          <artwork align="left"><![CDATA[
+         
      0                   1                   2                   3
      0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -1461,61 +1482,58 @@ IOAM proof of transit option data MUST be 4-octet aligned:
     |                          Microseconds                         |
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
            ]]></artwork>
+        </figure>
 
-     </figure>
+        <t>Timestamp field format: <list hangIndent="10" style="empty">
+            <t>Seconds: specifies the integer portion of the number of seconds
+            since the epoch.</t>
 
+            <t>+ Size: 32 bits.</t>
 
-     <t>Timestamp field format: <list
-         hangIndent="10" style="empty">
-         <t>Seconds: specifies the integer portion of the number of seconds 
-		 since the epoch.</t>
-		 <t>+ Size: 32 bits.</t>
-		 <t>+ Units: seconds.</t>
-         <t>Microseconds: specifies the fractional portion of the number of 
-		 seconds since the epoch.</t>
-		 <t>+ Size: 32 bits.</t>
-		 <t>+ Units: the unit is microseconds. The value of this field is in 
-		 the range 0 to (10^6)-1.</t>
-       </list></t>
+            <t>+ Units: seconds.</t>
 
-     <t>Epoch: <list
-         hangIndent="10" style="empty">
-         <t>The epoch is 1 January 1970 00:00:00 TAI, which is 31 December 1969 
-		 23:59:51.999918 UTC.</t>
-       </list></t>
+            <t>Microseconds: specifies the fractional portion of the number of
+            seconds since the epoch.</t>
 
-     <t>Resolution: <list
-         hangIndent="10" style="empty">
-         <t>The resolution is 1 microsecond.</t>
-       </list></t>
-	   
-     <t>Wraparound: <list
-         hangIndent="10" style="empty">
-         <t>This time format wraps around every 2^32 seconds, which is roughly 
-		 136 years. The next wraparound will occur in the year 2106.</t>
-       </list></t>
+            <t>+ Size: 32 bits.</t>
 
-     <t>Synchronization Aspects: <list
-         hangIndent="10" style="empty">
-         <t>It is assumed that nodes that use this timestamp format run Linux 
-		 operating system, and hence use the POSIX time. In some cases nodes 
-		 may be synchronized to UTC using a synchronization mechanism that is 
-		 outside the scope of this document, such as NTP 
-		 <xref target="RFC5905"></xref>. Thus, the timestamp may be derived 
-		 from the NTP-synchronized clock, allowing the timestamp to be measured 
-		 with respect to the clock of an NTP server.</t> 
-		 <t>The POSIX-based timestamp format is affected by leap seconds; it 
-		 represents the number of seconds since the epoch minus the number of 
-		 leap seconds that have occurred since the epoch. The value of a 
-		 timestamp during or slightly after a leap second may be temporarily 
-		 inaccurate.</t>
-       </list></t>
-	   
-	</section>
+            <t>+ Units: the unit is microseconds. The value of this field is
+            in the range 0 to (10^6)-1.</t>
+          </list></t>
 
-	
-	</section>
-	
+        <t>Epoch: <list hangIndent="10" style="empty">
+            <t>The epoch is 1 January 1970 00:00:00 TAI, which is 31 December
+            1969 23:59:51.999918 UTC.</t>
+          </list></t>
+
+        <t>Resolution: <list hangIndent="10" style="empty">
+            <t>The resolution is 1 microsecond.</t>
+          </list></t>
+
+        <t>Wraparound: <list hangIndent="10" style="empty">
+            <t>This time format wraps around every 2^32 seconds, which is
+            roughly 136 years. The next wraparound will occur in the year
+            2106.</t>
+          </list></t>
+
+        <t>Synchronization Aspects: <list hangIndent="10" style="empty">
+            <t>It is assumed that nodes that use this timestamp format run
+            Linux operating system, and hence use the POSIX time. In some
+            cases nodes may be synchronized to UTC using a synchronization
+            mechanism that is outside the scope of this document, such as NTP
+            <xref target="RFC5905"></xref>. Thus, the timestamp may be derived
+            from the NTP-synchronized clock, allowing the timestamp to be
+            measured with respect to the clock of an NTP server.</t>
+
+            <t>The POSIX-based timestamp format is affected by leap seconds;
+            it represents the number of seconds since the epoch minus the
+            number of leap seconds that have occurred since the epoch. The
+            value of a timestamp during or slightly after a leap second may be
+            temporarily inaccurate.</t>
+          </list></t>
+      </section>
+    </section>
+
     <section title="IOAM Data Export">
       <t>IOAM nodes collect information for packets traversing a domain that
       supports IOAM. IOAM decapsulating nodes as well as IOAM transit nodes
@@ -1537,6 +1555,8 @@ IOAM proof of transit option data MUST be 4-octet aligned:
         names are listed below:</t>
 
         <t><list style="empty">
+            <t>IOAM Type</t>
+
             <t>IOAM Trace Type</t>
 
             <t>IOAM Trace flags</t>
@@ -1546,47 +1566,66 @@ IOAM proof of transit option data MUST be 4-octet aligned:
             <t>IOAM E2E Type</t>
           </list>will contain the current set of possibilities defined in this
         document. New registries in this name space are created via RFC
-        Required process as per <xref target="RFC8126"/>.</t>
+        Required process as per <xref target="RFC8126"></xref>.</t>
 
         <t>The subsequent sub-sections detail the registries herein
         contained.</t>
       </section>
 
+      <section title="IOAM Type Registry">
+        <t>This registry defines 256 code points to define IOAM-Type field for
+        identifying IOAM options as explained in <xref
+        target="IOAM_option_format"></xref>. The following code points are
+        defined in this draft:</t>
+
+        <t><list style="hanging">
+            <t hangText="0">IOAM Pre-allocated Trace Option Type</t>
+
+            <t hangText="1">IOAM Incremental Trace Option Type</t>
+
+            <t hangText="2">IOAM POT Option Type</t>
+
+            <t hangText="3">IOAM E2E Option Type</t>
+          </list>4 - 255 are available for assignment via RFC Required process
+        as per <xref target="RFC8126"></xref>.</t>
+      </section>
+
       <section title="IOAM Trace Type Registry">
         <t>This registry defines code point for each bit in the 16-bit
         IOAM-Trace-Type field for Pre-allocated trace option and Incremental
-        trace option defined in <xref target="IOAM_tracing_option"/>. The
-        meaning of Bit 0 - 11 for trace type are defined in this document in
-        <xref target="IOAMTraceType"/> <xref
+        trace option defined in <xref target="IOAM_tracing_option"></xref>.
+        The meaning of Bit 0 - 11 for trace type are defined in this document
+        in <xref target="IOAMTraceType"></xref> <xref
         target="TraceOptionDef">of</xref>. The meaning for Bit 12 - 15 are
         available for assignment via RFC Required process as per <xref
-        target="RFC8126"/>.</t>
+        target="RFC8126"></xref>.</t>
       </section>
 
       <section title="IOAM Trace Flags Registry">
         <t>This registry defines code point for each bit in the 4 bit flags
         for Pre-allocated trace option and Incremental trace option defined in
-        <xref target="IOAM_tracing_option"/>. The meaning of Bit 0 - 1 for
-        trace flags are defined in this document in <xref
-        target="TraceFlags"/> of <xref target="TraceOptionDef"/>. The meaning
-        for Bit 2 - 3 are available for assignment via RFC Required process as
-        per <xref target="RFC8126"/>.</t>
+        <xref target="IOAM_tracing_option"></xref>. The meaning of Bit 0 - 1
+        for trace flags are defined in this document in <xref
+        target="TraceFlags"></xref> of <xref target="TraceOptionDef"></xref>.
+        The meaning for Bit 2 - 3 are available for assignment via RFC
+        Required process as per <xref target="RFC8126"></xref>.</t>
       </section>
 
       <section title="IOAM POT Type Registry">
         <t>This registry defines 128 code points to define IOAM POT Type for
         IOAM proof of transit option <xref
-        target="IOAM_proof_of_transit_option"/>. The code point value 0 is
-        defined in this document, 1 - 127 are available for assignment via RFC
-        Required process as per <xref target="RFC8126"/>.</t>
+        target="IOAM_proof_of_transit_option"></xref>. The code point value 0
+        is defined in this document, 1 - 127 are available for assignment via
+        RFC Required process as per <xref target="RFC8126"></xref>.</t>
       </section>
 
       <section title="IOAM E2E Type Registry">
-        <t>This registry defines 256 code points to define IOAM-E2E-Type for
-        IOAM E2E option <xref target="IOAM_edge_to_edge_opt"/>. The meaning of
-        Bit 0 - 3 are defined in this document. The meaning of Bit 4 - 7 are
-        available for assignments via RFC Required process as per <xref
-        target="RFC8126"/>.</t>
+        <t>This registry defines code points for each bit in the 16 bit
+        IOAM-E2E-Type field for IOAM E2E option <xref
+        target="IOAM_edge_to_edge_opt"></xref>. The meaning of Bit 0 - 3 are
+        defined in this document. The meaning of Bit 4 - 15 are available for
+        assignments via RFC Required process as per <xref
+        target="RFC8126"></xref>.</t>
       </section>
     </section>
 
@@ -1599,7 +1638,7 @@ IOAM proof of transit option data MUST be 4-octet aligned:
       <t>Security considerations will be addressed &iacute;n a later version
       of this document. For a discussion of security requirements of in-situ
       OAM, please refer to <xref
-      target="I-D.brockners-inband-oam-requirements"/>.</t>
+      target="I-D.brockners-inband-oam-requirements"></xref>.</t>
     </section>
 
     <section title="Acknowledgements">
@@ -1609,7 +1648,7 @@ IOAM proof of transit option data MUST be 4-octet aligned:
       Yourtchenko for the comments and advice.</t>
 
       <t>This document leverages and builds on top of several concepts
-      described in <xref target="I-D.kitamura-ipv6-record-route"/>. The
+      described in <xref target="I-D.kitamura-ipv6-record-route"></xref>. The
       authors would like to acknowledge the work done by the author Hiroshi
       Kitamura and people involved in writing it.</t>
 
@@ -1654,10 +1693,10 @@ IOAM proof of transit option data MUST be 4-octet aligned:
             Engineers</organization>
           </author>
 
-          <date year="2008"/>
+          <date year="2008" />
         </front>
 
-        <seriesInfo name="" value="IEEE Std 1003.1-2008"/>
+        <seriesInfo name="" value="IEEE Std 1003.1-2008" />
       </reference>
 
       <reference anchor="IEEE1588v2"
@@ -1672,10 +1711,10 @@ IOAM proof of transit option data MUST be 4-octet aligned:
             Engineers</organization>
           </author>
 
-          <date year="2008"/>
+          <date year="2008" />
         </front>
 
-        <seriesInfo name="" value="IEEE Std 1588-2008"/>
+        <seriesInfo name="" value="IEEE Std 1588-2008" />
       </reference>
     </references>
 
@@ -1697,16 +1736,16 @@ IOAM proof of transit option data MUST be 4-octet aligned:
           <title>Record Route for IPv6 (PR6) Hop-by-Hop Option
           Extension</title>
 
-          <author fullname="Hiroshi Kitamura" initials="H" surname="Kitamura"/>
+          <author fullname="Hiroshi Kitamura" initials="H" surname="Kitamura"></author>
 
-          <date month="November" year="2000"/>
+          <date month="November" year="2000" />
         </front>
 
         <seriesInfo name="Internet-Draft"
-                    value="draft-kitamura-ipv6-record-route-00"/>
+                    value="draft-kitamura-ipv6-record-route-00" />
 
         <format target="https://tools.ietf.org/id/draft-kitamura-ipv6-record-route-00.txt"
-                type="TXT"/>
+                type="TXT" />
       </reference>
 
       &I-D.brockners-inband-oam-transport;
@@ -1718,9 +1757,8 @@ IOAM proof of transit option data MUST be 4-octet aligned:
       &I-D.ietf-nvo3-vxlan-gpe;
 
       &I-D.ietf-nvo3-geneve;
-	  
+
       &I-D.ietf-ntp-packet-timestamps;
-	  
     </references>
   </back>
 </rfc>

--- a/drafts/draft-ietf-ippm-ioam-data.xml
+++ b/drafts/draft-ietf-ippm-ioam-data.xml
@@ -462,21 +462,23 @@
 
     <section anchor="IOAM_option_format" title="IOAM Data Types and Formats">
       <t>This section defines IOAM data types and data fields and associated
-      data types required for IOAM. The different uses of IOAM require the
-      definition of different types of data. The IOAM data fields for the data
-      being carried corresponds to the three main categories of IOAM data
-      defined in <xref target="I-D.brockners-inband-oam-requirements"></xref>,
-      which are: edge-to-edge, per node, and for selected nodes only.</t>
+      data types required for IOAM.</t>
+
+      <t>To accommodate the different uses of IOAM, three main categories of
+      IOAM data are defined in <xref
+      target="I-D.brockners-inband-oam-requirements"></xref>, which are:
+      edge-to-edge, per node, and for selected nodes only. Corresponding to
+      these categories, IOAM data fields are encoded in different IOAM
+      options, each with its own definition of data types and data fields. In
+      many cases, a bit field determines the set of IOAM data fields embedded
+      in that IOAM option in the packet. </t>
 
       <t>Encapsulation options for IOAM data are outside the scope of this
       memo, and are discussed in <xref
-      target="I-D.brockners-inband-oam-transport"></xref>. A bit field
-      determines the set of OAM data fields embedded in a packet. Depending on
-      the type of the encapsulation, a type and length field indicates type
-      and length of the data fields that are included in a particular packet.
-      For the encapsulations where IOAM uses its own name space to distinguish
-      between the various data type options defined in this section, IOAM-Type
-      registry is defined with the following code points to identify the IOAM
+      target="I-D.brockners-inband-oam-transport"></xref>. One exception is
+      for encapsulations where IOAM uses its own name space to distinguish
+      between the IOAM options. For these encapsulations, a common IOAM-Type
+      registry is defined, with the following code points to identify the IOAM
       options:</t>
 
       <t><list style="hanging">
@@ -1190,11 +1192,11 @@ IOAM proof of transit option header:
 
 IOAM proof of transit option data MUST be 4-octet aligned.:
     
-  0                   1                   2                   3
-  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
- +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
- |       POT Option data field determined by IOAM-POT-Type       ~
- +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ 0                   1                   2                   3
+ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|       POT Option data field determined by IOAM-POT-Type       |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 
 
 ]]></artwork>
@@ -1209,13 +1211,17 @@ IOAM proof of transit option data MUST be 4-octet aligned.:
             <t hangText="IOAM POT flags:">8-bit. Following flags are
             defined:<list style="hanging">
                 <t hangText="Bit 0">"Profile-to-use" (P-bit) (most significant
-                bit). Indicates which POT-profile is used by POT Type 0.</t>
+                bit). For IOAM POT types that use a maximum of two profiles to
+                drive computation, indicates which POT-profile is used. The
+                two profiles are numbered 0, 1. </t>
 
-                <t hangText="Bit 1-7">Reserved: Must be zero.</t>
+                <t hangText="Bit 1-7">Reserved: Must be set to zero upon
+                transmission and ignored upon receipt.</t>
               </list></t>
 
             <t hangText="Reserved:">16-bit Reserved bits are present for
-            future use. The reserved bits MUST be set to 0x0.</t>
+            future use. The reserved bits Must be set to zero upon
+            transmission and ignored upon receipt.</t>
 
             <t hangText="POT Option data:">Variable-length field. The type of
             which is determined by the IOAM-POT-Type.</t>
@@ -1244,8 +1250,9 @@ IOAM proof of transit option of IOAM POT Type 0:
 ]]></artwork>
             </figure><list style="hanging">
               <t hangText="IOAM POT Type:">8-bit identifier of a particular
-              POT variant that dictates the POT data that is included, to be
-              set to 0 for the POT defined in this section.</t>
+              POT variant that dictates the POT data that is included. This
+              section defines the POT data when the IOAM POT Type is set to
+              the value 0. </t>
 
               <t hangText="P bit:">1-bit. "Profile-to-use" (P-bit) (most
               significant bit). Indicates which POT-profile is used to
@@ -1256,10 +1263,12 @@ IOAM proof of transit option of IOAM POT Type 0:
               Cumulative.</t>
 
               <t hangText="R (7 bits):">7-bit IOAM POT flags for future use.
-              MUST be zero on transmission and ignored on receipt. </t>
+              MUST be set to zero upon transmission and ignored upon receipt.
+              </t>
 
               <t hangText="Reserved:">16-bit Reserved bits are present for
-              future use. The reserved bits MUST be set to 0x0.</t>
+              future use. The reserved bits Must be set to zero upon
+              transmission and ignored upon receipt.</t>
 
               <t hangText="Random:">64-bit Per packet Random number.</t>
 
@@ -1292,8 +1301,8 @@ IOAM proof of transit option of IOAM POT Type 0:
 
    IOAM edge-to-edge option header:
    
-   0                   1                   2                   3
-   0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+    0                   1                   2                   3
+    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
    |         IOAM-E2E-Type         |             Reserved          |
    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -1308,10 +1317,12 @@ IOAM proof of transit option of IOAM POT Type 0:
 
 ]]></artwork>
           </figure><list style="hanging">
-            <t hangText="IOAM-E2E-Type:">16-bit identifier of a particular in
-            situ OAM E2E variant. The order of packing the E2E option data
-            field elements follows the bit order of the IOAM-E2E-Type field,
-            as follows:<list hangIndent="9" style="hanging">
+            <t hangText="IOAM-E2E-Type:">A 16-bit identifier which specifies
+            which data types are used in the E2E option data. The
+            IOAM-E2E-Type value is a bit field. The order of packing the E2E
+            option data field elements follows the bit order of the
+            IOAM-E2E-Type field, as follows:<list hangIndent="9"
+                style="hanging">
                 <t hangText="Bit 0">(Most significant bit) When set indicates
                 presence of a 64-bit sequence number added to a specific tube
                 which is used to identify packet loss and reordering for that
@@ -1355,11 +1366,13 @@ IOAM proof of transit option of IOAM POT Type 0:
                 in order to detect the error indication.</t>
 
                 <t hangText="Bit 4-15">Undefined. An IOAM encapsulating node
-                must set the value of each of these bits to 0.</t>
+                Must set the value of these bits to zero upon transmission and
+                ignore upon receipt.</t>
               </list></t>
 
             <t hangText="Reserved:">16-bits Reserved bits are present for
-            future use. The reserved bits MUST be set to 0x0.</t>
+            future use. The reserved bits Must be set to zero upon
+            transmission and ignored upon receipt.</t>
 
             <t hangText="E2E Option data:">Variable-length field. The type of
             which is determined by the IOAM-E2E-Type.</t>
@@ -1618,7 +1631,7 @@ IOAM proof of transit option of IOAM POT Type 0:
       </section>
 
       <section title="IOAM Type Registry">
-        <t>This registry defines 128 code points to define IOAM-Type field for
+        <t>This registry defines 128 code points for the IOAM-Type field for
         identifying IOAM options as explained in <xref
         target="IOAM_option_format"></xref>. The following code points are
         defined in this draft:</t>

--- a/drafts/versions/02/draft-ietf-ippm-ioam-data-02.txt
+++ b/drafts/versions/02/draft-ietf-ippm-ioam-data-02.txt
@@ -91,21 +91,21 @@ Table of Contents
        4.1.2.  IOAM node data fields and associated formats  . . . .  12
        4.1.3.  Examples of IOAM node data  . . . . . . . . . . . . .  17
      4.2.  IOAM Proof of Transit Option  . . . . . . . . . . . . . .  19
-     4.3.  IOAM Edge-to-Edge Option  . . . . . . . . . . . . . . . .  21
-   5.  Timestamp Formats . . . . . . . . . . . . . . . . . . . . . .  22
+       4.2.1.  IOAM Proof of Transit Type 0  . . . . . . . . . . . .  20
+     4.3.  IOAM Edge-to-Edge Option  . . . . . . . . . . . . . . . .  22
+   5.  Timestamp Formats . . . . . . . . . . . . . . . . . . . . . .  23
      5.1.  PTP Truncated Timestamp Format  . . . . . . . . . . . . .  23
-     5.2.  NTP 64-bit Timestamp Format . . . . . . . . . . . . . . .  24
-     5.3.  POSIX-based Timestamp Format  . . . . . . . . . . . . . .  25
+     5.2.  NTP 64-bit Timestamp Format . . . . . . . . . . . . . . .  25
+     5.3.  POSIX-based Timestamp Format  . . . . . . . . . . . . . .  26
    6.  IOAM Data Export  . . . . . . . . . . . . . . . . . . . . . .  27
-   7.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  27
+   7.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  28
      7.1.  Creation of a new In-Situ OAM  Protocol Parameters
-           Registry (IOAM) Protocol Parameters IANA registry . . . .  27
-     7.2.  IOAM Type Registry  . . . . . . . . . . . . . . . . . . .  27
-     7.3.  IOAM Trace Type Registry  . . . . . . . . . . . . . . . .  28
-     7.4.  IOAM Trace Flags Registry . . . . . . . . . . . . . . . .  28
-     7.5.  IOAM POT Type Registry  . . . . . . . . . . . . . . . . .  28
-     7.6.  IOAM E2E Type Registry  . . . . . . . . . . . . . . . . .  28
-   8.  Manageability Considerations  . . . . . . . . . . . . . . . .  28
+           Registry (IOAM) Protocol Parameters IANA registry . . . .  28
+     7.2.  IOAM Type Registry  . . . . . . . . . . . . . . . . . . .  28
+     7.3.  IOAM Trace Type Registry  . . . . . . . . . . . . . . . .  29
+     7.4.  IOAM Trace Flags Registry . . . . . . . . . . . . . . . .  29
+     7.5.  IOAM POT Type Registry  . . . . . . . . . . . . . . . . .  29
+     7.6.  IOAM POT Flags Registry . . . . . . . . . . . . . . . . .  29
 
 
 
@@ -114,12 +114,14 @@ Brockners, et al.       Expires September 1, 2018               [Page 2]
 Internet-Draft           In-situ OAM Data Fields           February 2018
 
 
-   9.  Security Considerations . . . . . . . . . . . . . . . . . . .  29
-   10. Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  29
-   11. References  . . . . . . . . . . . . . . . . . . . . . . . . .  29
-     11.1.  Normative References . . . . . . . . . . . . . . . . . .  29
-     11.2.  Informative References . . . . . . . . . . . . . . . . .  30
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  31
+     7.7.  IOAM E2E Type Registry  . . . . . . . . . . . . . . . . .  29
+   8.  Manageability Considerations  . . . . . . . . . . . . . . . .  29
+   9.  Security Considerations . . . . . . . . . . . . . . . . . . .  30
+   10. Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  30
+   11. References  . . . . . . . . . . . . . . . . . . . . . . . . .  30
+     11.1.  Normative References . . . . . . . . . . . . . . . . . .  30
+     11.2.  Informative References . . . . . . . . . . . . . . . . .  31
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  32
 
 1.  Introduction
 
@@ -161,14 +163,14 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
    Geneve:    Generic Network Virtualization Encapsulation
               [I-D.ietf-nvo3-geneve]
 
-   IOAM:      In-situ Operations, Administration, and Maintenance
-
 
 
 Brockners, et al.       Expires September 1, 2018               [Page 3]
 
 Internet-Draft           In-situ OAM Data Fields           February 2018
 
+
+   IOAM:      In-situ Operations, Administration, and Maintenance
 
    MTU:       Maximum Transmit Unit
 
@@ -216,8 +218,6 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
    ensure that the MTU of all links within a domain is sufficiently
    large to support the increased packet size due to IOAM) and ICMP
    message handling (i.e. in case of a native IPv6 transport, IOAM
-   support for ICMPv6 Echo Request/Reply could desired which would
-
 
 
 
@@ -226,6 +226,7 @@ Brockners, et al.       Expires September 1, 2018               [Page 4]
 Internet-Draft           In-situ OAM Data Fields           February 2018
 
 
+   support for ICMPv6 Echo Request/Reply could desired which would
    translate into ICMPv6 extensions to enable IOAM data fields to be
    copied from an Echo Request message to an Echo Reply message).
 
@@ -273,7 +274,6 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
 
    Encapsulation options for IOAM data are outside the scope of this
    memo, and are discussed in [I-D.brockners-inband-oam-transport].  A
-   bit field determines the set of OAM data fields embedded in a packet.
 
 
 
@@ -282,6 +282,7 @@ Brockners, et al.       Expires September 1, 2018               [Page 5]
 Internet-Draft           In-situ OAM Data Fields           February 2018
 
 
+   bit field determines the set of OAM data fields embedded in a packet.
    Depending on the type of the encapsulation, a type and length field
    indicates type and length of the data fields that are included in a
    particular packet.  For the encapsulations where IOAM uses its own
@@ -328,8 +329,7 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
    information will only be collected on those nodes which are IOAM
    capable.  Nodes which are not IOAM capable will forward the packet
    without any changes to the IOAM data fields.  The maximum number of
-   hops and the minimum path MTU of the IOAM domain is assumed to be
-   known.
+
 
 
 
@@ -337,6 +337,9 @@ Brockners, et al.       Expires September 1, 2018               [Page 6]
 
 Internet-Draft           In-situ OAM Data Fields           February 2018
 
+
+   hops and the minimum path MTU of the IOAM domain is assumed to be
+   known.
 
    To optimize hardware and software implementations tracing is defined
    as two separate options.  Any deployment MAY choose to configure and
@@ -383,9 +386,6 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
    transit node that is traversed by a packet.  The in-situ OAM
    decapsulating node removes the IOAM data and processes and/or exports
    the metadata.  IOAM data uses its own name-space for information such
-   as node identifier or interface identifier.  This allows for a
-   domain-specific definition and interpretation.  For example: In one
-   case an interface-id could point to a physical interface (e.g., to
 
 
 
@@ -394,6 +394,9 @@ Brockners, et al.       Expires September 1, 2018               [Page 7]
 Internet-Draft           In-situ OAM Data Fields           February 2018
 
 
+   as node identifier or interface identifier.  This allows for a
+   domain-specific definition and interpretation.  For example: In one
+   case an interface-id could point to a physical interface (e.g., to
    understand which physical interface of an aggregated link is used
    when receiving or transmitting a packet) whereas in another case it
    could refer to a logical interface (e.g., in case of tunnels).
@@ -439,9 +442,6 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
    incremental trace option have similar formats.  Except where noted
    below, the internal formats and fields of the two trace options are
    identical.
-
-
-
 
 
 
@@ -1073,13 +1073,61 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
     0                   1                   2                   3
     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-   |IOAM POT Type|P|             Reserved                          |
+   |IOAM POT Type  | IOAM POT flags|           Reserved            |
    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 
-   IOAM proof of transit option data MUST be 4-octet aligned:
+   IOAM proof of transit option data MUST be 4-octet aligned.:
+
+     0                   1                   2                   3
+     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |       POT Option data field determined by IOAM-POT-Type       ~
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+
+
+   IOAM POT Type:  8-bit identifier of a particular POT variant that
+      dictates the POT data that is included.  This document defines POT
+      Type 0:
+
+      0: POT data is a 16 Octet field as described below.
+
+   IOAM POT flags:  8-bit.  Following flags are defined:
+
+      Bit 0  "Profile-to-use" (P-bit) (most significant bit).  Indicates
+         which POT-profile is used by POT Type 0.
+
+      Bit 1-7  Reserved: Must be zero.
+
+   Reserved:  16-bit Reserved bits are present for future use.  The
+      reserved bits MUST be set to 0x0.
+
+   POT Option data:  Variable-length field.  The type of which is
+      determined by the IOAM-POT-Type.
+
+4.2.1.  IOAM Proof of Transit Type 0
+
+
+
+
+
+
+
+
+
+
+
+Brockners, et al.       Expires September 1, 2018              [Page 20]
+
+Internet-Draft           In-situ OAM Data Fields           February 2018
+
+
+   IOAM proof of transit option of IOAM POT Type 0:
 
     0                   1                   2                   3
     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |IOAM POT Type=0|P|IOAM POTFlags|           Reserved            |
    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+<-+
    |                           Random                              |  |
    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+  P
@@ -1092,20 +1140,23 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
 
 
 
-   IOAM POT Type:  7-bit identifier of a particular POT variant that
-      dictates the POT data that is included.  This document defines POT
-      Type 0:
+   IOAM POT Type:  8-bit identifier of a particular POT variant that
+      dictates the POT data that is included, to be set to 0 for the POT
+      defined in this section.
 
-      0: POT data is a 16 Octet field as described below.
+   IOAM POT flags:  8-bit.  Following flags are defined:
 
-   Reserved:  24-bit Reserved bits are present for future use.  The
+      Bit 0  "Profile-to-use" (P-bit) (most significant bit).  Indicates
+         which POT-profile is used to generate the Cumulative.  Any node
+         participating in POT will have a maximum of 2 profiles
+         configured that drive the computation of cumulative.  The two
+         profiles are numbered 0, 1.  This bit conveys whether profile 0
+         or profile 1 is used to compute the Cumulative.
+
+      Bit 1-7  Reserved: Must be zero.
+
+   Reserved:  16-bit Reserved bits are present for future use.  The
       reserved bits MUST be set to 0x0.
-
-   Profile to use (P):  1-bit.  Indicates which POT-profile is used to
-      generate the Cumulative.  Any node participating in POT will have
-      a maximum of 2 profiles configured that drive the computation of
-      cumulative.  The two profiles are numbered 0, 1.  This bit conveys
-      whether profile 0 or profile 1 is used to compute the Cumulative.
 
    Random:  64-bit Per packet Random number.
 
@@ -1113,20 +1164,19 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
       processing per packet Random number field and configured
       parameters.
 
-
-
-
-
-Brockners, et al.       Expires September 1, 2018              [Page 20]
-
-Internet-Draft           In-situ OAM Data Fields           February 2018
-
-
    Note: Larger or smaller sizes of "Random" and "Cumulative" data are
-   feasible and could be required for certain deployments (e.g.  in case
+   feasible and could be required for certain deployments (e.g. in case
    of space constraints in the transport protocol used).  Future
    versions of this document will address different sizes of data for
    "proof of transit".
+
+
+
+
+Brockners, et al.       Expires September 1, 2018              [Page 21]
+
+Internet-Draft           In-situ OAM Data Fields           February 2018
+
 
 4.3.  IOAM Edge-to-Edge Option
 
@@ -1168,16 +1218,6 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
                used to identify packet loss and reordering for that
                tube.
 
-
-
-
-
-
-Brockners, et al.       Expires September 1, 2018              [Page 21]
-
-Internet-Draft           In-situ OAM Data Fields           February 2018
-
-
       Bit 1    When set indicates presence of a 32-bit sequence number
                added to a specific tube which is used to identify packet
                loss and reordering for that tube.
@@ -1186,6 +1226,14 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
                transmission of the frame.  This 4-octet field has three
                possible formats; based on either PTP [IEEE1588v2], NTP
                [RFC5905], or POSIX [POSIX].  The three timestamp formats
+
+
+
+Brockners, et al.       Expires September 1, 2018              [Page 22]
+
+Internet-Draft           In-situ OAM Data Fields           February 2018
+
+
                are specified in Section 5.  In all three cases, the
                Timestamp Seconds field contains the 32 most significant
                bits of the timestamp format that is specified in
@@ -1216,23 +1264,15 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
    Reserved:  16-bits Reserved bits are present for future use.  The
       reserved bits MUST be set to 0x0.
 
+   E2E Option data:  Variable-length field.  The type of which is
+      determined by the IOAM-E2E-Type.
+
 5.  Timestamp Formats
 
    The IOAM data fields include a timestamp field which is represented
    in one of three possible timestamp formats.  It is assumed that the
    management plane is responsible for determining which timestamp
    format is used.
-
-
-
-
-
-
-
-Brockners, et al.       Expires September 1, 2018              [Page 22]
-
-Internet-Draft           In-situ OAM Data Fields           February 2018
-
 
 5.1.  PTP Truncated Timestamp Format
 
@@ -1242,6 +1282,12 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
    The PTP truncated format is specified in Section 4.3 of
    [I-D.ietf-ntp-packet-timestamps], and the details are presented below
    for the sake of completeness.
+
+
+
+Brockners, et al.       Expires September 1, 2018              [Page 23]
+
+Internet-Draft           In-situ OAM Data Fields           February 2018
 
 
         0                   1                   2                   3
@@ -1282,14 +1328,6 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
 
    Wraparound:
 
-
-
-
-Brockners, et al.       Expires September 1, 2018              [Page 23]
-
-Internet-Draft           In-situ OAM Data Fields           February 2018
-
-
       This time format wraps around every 2^32 seconds, which is roughly
       136 years.  The next wraparound will occur in the year 2106.
 
@@ -1299,6 +1337,15 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
       among themselves.  Nodes may be synchronized to a global reference
       time.  Note that if PTP [IEEE1588v2] is used for synchronization,
       the timestamp may be derived from the PTP-synchronized clock,
+
+
+
+
+Brockners, et al.       Expires September 1, 2018              [Page 24]
+
+Internet-Draft           In-situ OAM Data Fields           February 2018
+
+
       allowing the timestamp to be measured with respect to the clock of
       an PTP Grandmaster clock.
 
@@ -1337,15 +1384,6 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
 
       + Size: 32 bits.
 
-
-
-
-
-Brockners, et al.       Expires September 1, 2018              [Page 24]
-
-Internet-Draft           In-situ OAM Data Fields           February 2018
-
-
       + Units: the unit is 2^(-32) seconds, which is roughly equal to
       233 picoseconds.
 
@@ -1356,6 +1394,13 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
    Resolution:
 
       The resolution is 2^(-32) seconds.
+
+
+
+Brockners, et al.       Expires September 1, 2018              [Page 25]
+
+Internet-Draft           In-situ OAM Data Fields           February 2018
+
 
    Wraparound:
 
@@ -1394,14 +1439,6 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
 
    Timestamp field format:
 
-
-
-
-Brockners, et al.       Expires September 1, 2018              [Page 25]
-
-Internet-Draft           In-situ OAM Data Fields           February 2018
-
-
       Seconds: specifies the integer portion of the number of seconds
       since the epoch.
 
@@ -1413,6 +1450,13 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
       seconds since the epoch.
 
       + Size: 32 bits.
+
+
+
+Brockners, et al.       Expires September 1, 2018              [Page 26]
+
+Internet-Draft           In-situ OAM Data Fields           February 2018
+
 
       + Units: the unit is microseconds.  The value of this field is in
       the range 0 to (10^6)-1.
@@ -1447,17 +1491,6 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
       a timestamp during or slightly after a leap second may be
       temporarily inaccurate.
 
-
-
-
-
-
-
-Brockners, et al.       Expires September 1, 2018              [Page 26]
-
-Internet-Draft           In-situ OAM Data Fields           February 2018
-
-
 6.  IOAM Data Export
 
    IOAM nodes collect information for packets traversing a domain that
@@ -1468,6 +1501,18 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
 
    The discussion of IOAM data processing and export is left for a
    future version of this document.
+
+
+
+
+
+
+
+
+Brockners, et al.       Expires September 1, 2018              [Page 27]
+
+Internet-Draft           In-situ OAM Data Fields           February 2018
+
 
 7.  IANA Considerations
 
@@ -1489,6 +1534,8 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
 
       IOAM POT Type
 
+      IOAM POT flags
+
       IOAM E2E Type
 
    will contain the current set of possibilities defined in this
@@ -1499,7 +1546,7 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
 
 7.2.  IOAM Type Registry
 
-   This registry defines 256 code points to define IOAM-Type field for
+   This registry defines 128 code points to define IOAM-Type field for
    identifying IOAM options as explained in Section 4.  The following
    code points are defined in this draft:
 
@@ -1507,19 +1554,21 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
 
    1  IOAM Incremental Trace Option Type
 
-
-
-Brockners, et al.       Expires September 1, 2018              [Page 27]
-
-Internet-Draft           In-situ OAM Data Fields           February 2018
-
-
    2  IOAM POT Option Type
 
    3  IOAM E2E Option Type
 
-   4 - 255 are available for assignment via RFC Required process as per
+   4 - 127 are available for assignment via RFC Required process as per
    [RFC8126].
+
+
+
+
+
+Brockners, et al.       Expires September 1, 2018              [Page 28]
+
+Internet-Draft           In-situ OAM Data Fields           February 2018
+
 
 7.3.  IOAM Trace Type Registry
 
@@ -1541,12 +1590,20 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
 
 7.5.  IOAM POT Type Registry
 
-   This registry defines 128 code points to define IOAM POT Type for
+   This registry defines 256 code points to define IOAM POT Type for
    IOAM proof of transit option Section 4.2.  The code point value 0 is
-   defined in this document, 1 - 127 are available for assignment via
+   defined in this document, 1 - 255 are available for assignment via
    RFC Required process as per [RFC8126].
 
-7.6.  IOAM E2E Type Registry
+7.6.  IOAM POT Flags Registry
+
+   This registry defines code point for each bit in the 8 bit flags for
+   IOAM POT option defined in Section 4.2.  The meaning of Bit 0 for
+   IOAM POT flags is defined in this document in Section 4.2.  The
+   meaning for Bit 1 - 7 are available for assignment via RFC Required
+   process as per [RFC8126].
+
+7.7.  IOAM E2E Type Registry
 
    This registry defines code points for each bit in the 16 bit IOAM-
    E2E-Type field for IOAM E2E option Section 4.3.  The meaning of Bit 0
@@ -1564,8 +1621,7 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
 
 
 
-
-Brockners, et al.       Expires September 1, 2018              [Page 28]
+Brockners, et al.       Expires September 1, 2018              [Page 29]
 
 Internet-Draft           In-situ OAM Data Fields           February 2018
 
@@ -1621,7 +1677,7 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
 
 
 
-Brockners, et al.       Expires September 1, 2018              [Page 29]
+Brockners, et al.       Expires September 1, 2018              [Page 30]
 
 Internet-Draft           In-situ OAM Data Fields           February 2018
 
@@ -1677,7 +1733,7 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
 
 
 
-Brockners, et al.       Expires September 1, 2018              [Page 30]
+Brockners, et al.       Expires September 1, 2018              [Page 31]
 
 Internet-Draft           In-situ OAM Data Fields           February 2018
 
@@ -1733,7 +1789,7 @@ Authors' Addresses
 
 
 
-Brockners, et al.       Expires September 1, 2018              [Page 31]
+Brockners, et al.       Expires September 1, 2018              [Page 32]
 
 Internet-Draft           In-situ OAM Data Fields           February 2018
 
@@ -1789,7 +1845,7 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
 
 
 
-Brockners, et al.       Expires September 1, 2018              [Page 32]
+Brockners, et al.       Expires September 1, 2018              [Page 33]
 
 Internet-Draft           In-situ OAM Data Fields           February 2018
 
@@ -1845,4 +1901,4 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
 
 
 
-Brockners, et al.       Expires September 1, 2018              [Page 33]
+Brockners, et al.       Expires September 1, 2018              [Page 34]

--- a/drafts/versions/02/draft-ietf-ippm-ioam-data-02.txt
+++ b/drafts/versions/02/draft-ietf-ippm-ioam-data-02.txt
@@ -93,19 +93,19 @@ Table of Contents
      4.2.  IOAM Proof of Transit Option  . . . . . . . . . . . . . .  19
      4.3.  IOAM Edge-to-Edge Option  . . . . . . . . . . . . . . . .  21
    5.  Timestamp Formats . . . . . . . . . . . . . . . . . . . . . .  22
-     5.1.  PTP Truncated Timestamp Format  . . . . . . . . . . . . .  22
-     5.2.  NTP 64-bit Timestamp Format . . . . . . . . . . . . . . .  23
+     5.1.  PTP Truncated Timestamp Format  . . . . . . . . . . . . .  23
+     5.2.  NTP 64-bit Timestamp Format . . . . . . . . . . . . . . .  24
      5.3.  POSIX-based Timestamp Format  . . . . . . . . . . . . . .  25
-   6.  IOAM Data Export  . . . . . . . . . . . . . . . . . . . . . .  26
-   7.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  26
+   6.  IOAM Data Export  . . . . . . . . . . . . . . . . . . . . . .  27
+   7.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  27
      7.1.  Creation of a new In-Situ OAM  Protocol Parameters
-           Registry (IOAM) Protocol Parameters IANA registry . . . .  26
-     7.2.  IOAM Trace Type Registry  . . . . . . . . . . . . . . . .  27
-     7.3.  IOAM Trace Flags Registry . . . . . . . . . . . . . . . .  27
-     7.4.  IOAM POT Type Registry  . . . . . . . . . . . . . . . . .  27
-     7.5.  IOAM E2E Type Registry  . . . . . . . . . . . . . . . . .  27
+           Registry (IOAM) Protocol Parameters IANA registry . . . .  27
+     7.2.  IOAM Type Registry  . . . . . . . . . . . . . . . . . . .  27
+     7.3.  IOAM Trace Type Registry  . . . . . . . . . . . . . . . .  28
+     7.4.  IOAM Trace Flags Registry . . . . . . . . . . . . . . . .  28
+     7.5.  IOAM POT Type Registry  . . . . . . . . . . . . . . . . .  28
+     7.6.  IOAM E2E Type Registry  . . . . . . . . . . . . . . . . .  28
    8.  Manageability Considerations  . . . . . . . . . . . . . . . .  28
-   9.  Security Considerations . . . . . . . . . . . . . . . . . . .  28
 
 
 
@@ -114,11 +114,12 @@ Brockners, et al.       Expires September 1, 2018               [Page 2]
 Internet-Draft           In-situ OAM Data Fields           February 2018
 
 
-   10. Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  28
-   11. References  . . . . . . . . . . . . . . . . . . . . . . . . .  28
-     11.1.  Normative References . . . . . . . . . . . . . . . . . .  28
-     11.2.  Informative References . . . . . . . . . . . . . . . . .  29
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  30
+   9.  Security Considerations . . . . . . . . . . . . . . . . . . .  29
+   10. Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  29
+   11. References  . . . . . . . . . . . . . . . . . . . . . . . . .  29
+     11.1.  Normative References . . . . . . . . . . . . . . . . . .  29
+     11.2.  Informative References . . . . . . . . . . . . . . . . .  30
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  31
 
 1.  Introduction
 
@@ -161,7 +162,6 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
               [I-D.ietf-nvo3-geneve]
 
    IOAM:      In-situ Operations, Administration, and Maintenance
-
 
 
 
@@ -271,9 +271,9 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
    data defined in [I-D.brockners-inband-oam-requirements], which are:
    edge-to-edge, per node, and for selected nodes only.
 
-   Transport options for IOAM data are outside the scope of this memo,
-   and are discussed in [I-D.brockners-inband-oam-transport].  IOAM data
-   fields are fixed length data fields.  A bit field determines the set
+   Encapsulation options for IOAM data are outside the scope of this
+   memo, and are discussed in [I-D.brockners-inband-oam-transport].  A
+   bit field determines the set of OAM data fields embedded in a packet.
 
 
 
@@ -282,9 +282,20 @@ Brockners, et al.       Expires September 1, 2018               [Page 5]
 Internet-Draft           In-situ OAM Data Fields           February 2018
 
 
-   of OAM data fields embedded in a packet.  Depending on the type of
-   the encapsulation, a counter field indicates how many data fields are
-   included in a particular packet.
+   Depending on the type of the encapsulation, a type and length field
+   indicates type and length of the data fields that are included in a
+   particular packet.  For the encapsulations where IOAM uses its own
+   name space to distinguish between the various data type options
+   defined in this section, IOAM-Type registry is defined with the
+   following code points to identify the IOAM options:
+
+   0  IOAM Pre-allocated Trace Option Type
+
+   1  IOAM Incremental Trace Option Type
+
+   2  IOAM POT Option Type
+
+   3  IOAM E2E Option Type
 
    IOAM is expected to be deployed in a specific domain rather than on
    the overall Internet.  The part of the network which employs IOAM is
@@ -320,6 +331,13 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
    hops and the minimum path MTU of the IOAM domain is assumed to be
    known.
 
+
+
+Brockners, et al.       Expires September 1, 2018               [Page 6]
+
+Internet-Draft           In-situ OAM Data Fields           February 2018
+
+
    To optimize hardware and software implementations tracing is defined
    as two separate options.  Any deployment MAY choose to configure and
    support one or both of the following options.  An implementation of
@@ -330,13 +348,6 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
    operator knows which equipment is deployed in a particular IOAM, the
    operator will decide by means of configuration which type(s) of trace
    options will be enabled for a particular domain.
-
-
-
-Brockners, et al.       Expires September 1, 2018               [Page 6]
-
-Internet-Draft           In-situ OAM Data Fields           February 2018
-
 
    Pre-allocated Trace Option:  This trace option is defined as a
       container of node data fields with pre-allocated space for each
@@ -375,6 +386,14 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
    as node identifier or interface identifier.  This allows for a
    domain-specific definition and interpretation.  For example: In one
    case an interface-id could point to a physical interface (e.g., to
+
+
+
+Brockners, et al.       Expires September 1, 2018               [Page 7]
+
+Internet-Draft           In-situ OAM Data Fields           February 2018
+
+
    understand which physical interface of an aggregated link is used
    when receiving or transmitting a packet) whereas in another case it
    could refer to a logical interface (e.g., in case of tunnels).
@@ -384,15 +403,6 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
    o  Identification of the IOAM node.  An IOAM node identifier can
       match to a device identifier or a particular control point or
       subsystem within a device.
-
-
-
-
-
-Brockners, et al.       Expires September 1, 2018               [Page 7]
-
-Internet-Draft           In-situ OAM Data Fields           February 2018
-
 
    o  Identification of the interface that a packet was received on,
       i.e. ingress interface.
@@ -429,16 +439,6 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
    incremental trace option have similar formats.  Except where noted
    below, the internal formats and fields of the two trace options are
    identical.
-
-
-
-
-
-
-
-
-
-
 
 
 
@@ -1070,10 +1070,11 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
 
    IOAM proof of transit option header:
 
-    0 1 2 3 4 5 6 7
-   +-+-+-+-+-+-+-+-+
-   |IOAM POT Type|P|
-   +-+-+-+-+-+-+-+-+
+    0                   1                   2                   3
+    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |IOAM POT Type|P|             Reserved                          |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 
    IOAM proof of transit option data MUST be 4-octet aligned:
 
@@ -1097,6 +1098,9 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
 
       0: POT data is a 16 Octet field as described below.
 
+   Reserved:  24-bit Reserved bits are present for future use.  The
+      reserved bits MUST be set to 0x0.
+
    Profile to use (P):  1-bit.  Indicates which POT-profile is used to
       generate the Cumulative.  Any node participating in POT will have
       a maximum of 2 profiles configured that drive the computation of
@@ -1109,11 +1113,7 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
       processing per packet Random number field and configured
       parameters.
 
-   Note: Larger or smaller sizes of "Random" and "Cumulative" data are
-   feasible and could be required for certain deployments (e.g.  in case
-   of space constraints in the transport protocol used).  Future
-   versions of this document will address different sizes of data for
-   "proof of transit".
+
 
 
 
@@ -1121,6 +1121,12 @@ Brockners, et al.       Expires September 1, 2018              [Page 20]
 
 Internet-Draft           In-situ OAM Data Fields           February 2018
 
+
+   Note: Larger or smaller sizes of "Random" and "Cumulative" data are
+   feasible and could be required for certain deployments (e.g.  in case
+   of space constraints in the transport protocol used).  Future
+   versions of this document will address different sizes of data for
+   "proof of transit".
 
 4.3.  IOAM Edge-to-Edge Option
 
@@ -1138,10 +1144,11 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
 
       IOAM edge-to-edge option header:
 
-       0 1 2 3 4 5 6 7
-      +-+-+-+-+-+-+-+-+
-      | IOAM-E2E-Type |
-      +-+-+-+-+-+-+-+-+
+      0                   1                   2                   3
+      0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |         IOAM-E2E-Type         |             Reserved          |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 
       IOAM edge-to-edge option data MUST be 4-octet aligned:
 
@@ -1152,13 +1159,24 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 
 
-   IOAM-E2E-Type:  8-bit identifier of a particular in situ OAM E2E
-      variant.
+   IOAM-E2E-Type:  16-bit identifier of a particular in situ OAM E2E
+      variant.  The order of packing the E2E option data field elements
+      follows the bit order of the IOAM-E2E-Type field, as follows:
 
       Bit 0    (Most significant bit) When set indicates presence of a
                64-bit sequence number added to a specific tube which is
                used to identify packet loss and reordering for that
                tube.
+
+
+
+
+
+
+Brockners, et al.       Expires September 1, 2018              [Page 21]
+
+Internet-Draft           In-situ OAM Data Fields           February 2018
+
 
       Bit 1    When set indicates presence of a 32-bit sequence number
                added to a specific tube which is used to identify packet
@@ -1170,14 +1188,6 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
                [RFC5905], or POSIX [POSIX].  The three timestamp formats
                are specified in Section 5.  In all three cases, the
                Timestamp Seconds field contains the 32 most significant
-
-
-
-Brockners, et al.       Expires September 1, 2018              [Page 21]
-
-Internet-Draft           In-situ OAM Data Fields           February 2018
-
-
                bits of the timestamp format that is specified in
                Section 5.  If a node is not capable of populating this
                field, it assigns the value 0xFFFFFFFF.  Note that this
@@ -1200,12 +1210,29 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
                If the NTP format is used the analyzer should correlate
                several packets in order to detect the error indication.
 
+      Bit 4-15 Undefined.  An IOAM encapsulating node must set the value
+               of each of these bits to 0.
+
+   Reserved:  16-bits Reserved bits are present for future use.  The
+      reserved bits MUST be set to 0x0.
+
 5.  Timestamp Formats
 
    The IOAM data fields include a timestamp field which is represented
    in one of three possible timestamp formats.  It is assumed that the
    management plane is responsible for determining which timestamp
    format is used.
+
+
+
+
+
+
+
+Brockners, et al.       Expires September 1, 2018              [Page 22]
+
+Internet-Draft           In-situ OAM Data Fields           February 2018
+
 
 5.1.  PTP Truncated Timestamp Format
 
@@ -1226,13 +1253,6 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
        +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 
             Figure 1: PTP [IEEE1588] Truncated Timestamp Format
-
-
-
-Brockners, et al.       Expires September 1, 2018              [Page 22]
-
-Internet-Draft           In-situ OAM Data Fields           February 2018
-
 
    Timestamp field format:
 
@@ -1262,6 +1282,14 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
 
    Wraparound:
 
+
+
+
+Brockners, et al.       Expires September 1, 2018              [Page 23]
+
+Internet-Draft           In-situ OAM Data Fields           February 2018
+
+
       This time format wraps around every 2^32 seconds, which is roughly
       136 years.  The next wraparound will occur in the year 2106.
 
@@ -1281,15 +1309,6 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
 
    The Network Time Protocol (NTP) [RFC5905] timestamp format is 64 bits
    long.  This format is specified in Section 4.2.1 of
-
-
-
-
-Brockners, et al.       Expires September 1, 2018              [Page 23]
-
-Internet-Draft           In-situ OAM Data Fields           February 2018
-
-
    [I-D.ietf-ntp-packet-timestamps], and the details are presented below
    for the sake of completeness.
 
@@ -1318,6 +1337,15 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
 
       + Size: 32 bits.
 
+
+
+
+
+Brockners, et al.       Expires September 1, 2018              [Page 24]
+
+Internet-Draft           In-situ OAM Data Fields           February 2018
+
+
       + Units: the unit is 2^(-32) seconds, which is roughly equal to
       233 picoseconds.
 
@@ -1338,14 +1366,6 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
 
       Nodes that use this timestamp format will typically be
       synchronized to UTC using NTP [RFC5905].  Thus, the timestamp may
-
-
-
-Brockners, et al.       Expires September 1, 2018              [Page 24]
-
-Internet-Draft           In-situ OAM Data Fields           February 2018
-
-
       be derived from the NTP-synchronized clock, allowing the timestamp
       to be measured with respect to the clock of an NTP server.
 
@@ -1374,6 +1394,14 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
 
    Timestamp field format:
 
+
+
+
+Brockners, et al.       Expires September 1, 2018              [Page 25]
+
+Internet-Draft           In-situ OAM Data Fields           February 2018
+
+
       Seconds: specifies the integer portion of the number of seconds
       since the epoch.
 
@@ -1393,14 +1421,6 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
 
       The epoch is 1 January 1970 00:00:00 TAI, which is 31 December
       1969 23:59:51.999918 UTC.
-
-
-
-
-Brockners, et al.       Expires September 1, 2018              [Page 25]
-
-Internet-Draft           In-situ OAM Data Fields           February 2018
-
 
    Resolution:
 
@@ -1427,6 +1447,17 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
       a timestamp during or slightly after a leap second may be
       temporarily inaccurate.
 
+
+
+
+
+
+
+Brockners, et al.       Expires September 1, 2018              [Page 26]
+
+Internet-Draft           In-situ OAM Data Fields           February 2018
+
+
 6.  IOAM Data Export
 
    IOAM nodes collect information for packets traversing a domain that
@@ -1450,13 +1481,7 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
    include registrations for all IOAM namespaces.  Each Registry, whose
    names are listed below:
 
-
-
-
-Brockners, et al.       Expires September 1, 2018              [Page 26]
-
-Internet-Draft           In-situ OAM Data Fields           February 2018
-
+      IOAM Type
 
       IOAM Trace Type
 
@@ -1472,40 +1497,15 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
 
    The subsequent sub-sections detail the registries herein contained.
 
-7.2.  IOAM Trace Type Registry
+7.2.  IOAM Type Registry
 
-   This registry defines code point for each bit in the 16-bit IOAM-
-   Trace-Type field for Pre-allocated trace option and Incremental trace
-   option defined in Section 4.1.  The meaning of Bit 0 - 11 for trace
-   type are defined in this document in Paragraph 1 of (Section 4.1.1).
-   The meaning for Bit 12 - 15 are available for assignment via RFC
-   Required process as per [RFC8126].
+   This registry defines 256 code points to define IOAM-Type field for
+   identifying IOAM options as explained in Section 4.  The following
+   code points are defined in this draft:
 
-7.3.  IOAM Trace Flags Registry
+   0  IOAM Pre-allocated Trace Option Type
 
-   This registry defines code point for each bit in the 4 bit flags for
-   Pre-allocated trace option and Incremental trace option defined in
-   Section 4.1.  The meaning of Bit 0 - 1 for trace flags are defined in
-   this document in Paragraph 5 of Section 4.1.1.  The meaning for Bit 2
-   - 3 are available for assignment via RFC Required process as per
-   [RFC8126].
-
-7.4.  IOAM POT Type Registry
-
-   This registry defines 128 code points to define IOAM POT Type for
-   IOAM proof of transit option Section 4.2.  The code point value 0 is
-   defined in this document, 1 - 127 are available for assignment via
-   RFC Required process as per [RFC8126].
-
-7.5.  IOAM E2E Type Registry
-
-   This registry defines 256 code points to define IOAM-E2E-Type for
-   IOAM E2E option Section 4.3.  The meaning of Bit 0 - 3 are defined in
-   this document.  The meaning of Bit 4 - 7 are available for
-   assignments via RFC Required process as per [RFC8126].
-
-
-
+   1  IOAM Incremental Trace Option Type
 
 
 
@@ -1514,10 +1514,61 @@ Brockners, et al.       Expires September 1, 2018              [Page 27]
 Internet-Draft           In-situ OAM Data Fields           February 2018
 
 
+   2  IOAM POT Option Type
+
+   3  IOAM E2E Option Type
+
+   4 - 255 are available for assignment via RFC Required process as per
+   [RFC8126].
+
+7.3.  IOAM Trace Type Registry
+
+   This registry defines code point for each bit in the 16-bit IOAM-
+   Trace-Type field for Pre-allocated trace option and Incremental trace
+   option defined in Section 4.1.  The meaning of Bit 0 - 11 for trace
+   type are defined in this document in Paragraph 1 of (Section 4.1.1).
+   The meaning for Bit 12 - 15 are available for assignment via RFC
+   Required process as per [RFC8126].
+
+7.4.  IOAM Trace Flags Registry
+
+   This registry defines code point for each bit in the 4 bit flags for
+   Pre-allocated trace option and Incremental trace option defined in
+   Section 4.1.  The meaning of Bit 0 - 1 for trace flags are defined in
+   this document in Paragraph 5 of Section 4.1.1.  The meaning for Bit 2
+   - 3 are available for assignment via RFC Required process as per
+   [RFC8126].
+
+7.5.  IOAM POT Type Registry
+
+   This registry defines 128 code points to define IOAM POT Type for
+   IOAM proof of transit option Section 4.2.  The code point value 0 is
+   defined in this document, 1 - 127 are available for assignment via
+   RFC Required process as per [RFC8126].
+
+7.6.  IOAM E2E Type Registry
+
+   This registry defines code points for each bit in the 16 bit IOAM-
+   E2E-Type field for IOAM E2E option Section 4.3.  The meaning of Bit 0
+   - 3 are defined in this document.  The meaning of Bit 4 - 15 are
+   available for assignments via RFC Required process as per [RFC8126].
+
 8.  Manageability Considerations
 
    Manageability considerations will be addressed in a later version of
    this document..
+
+
+
+
+
+
+
+
+Brockners, et al.       Expires September 1, 2018              [Page 28]
+
+Internet-Draft           In-situ OAM Data Fields           February 2018
+
 
 9.  Security Considerations
 
@@ -1549,31 +1600,31 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
               Institute of Electrical and Electronics Engineers, "IEEE
               Std 1588-2008 - IEEE Standard for a Precision Clock
               Synchronization Protocol for Networked Measurement and
-              Control Systems",  IEEE Std 1588-2008, 2008,
+              Control Systems", IEEE Std 1588-2008, 2008,
               <http://standards.ieee.org/findstds/
               standard/1588-2008.html>.
 
    [POSIX]    Institute of Electrical and Electronics Engineers, "IEEE
               Std 1003.1-2008 (Revision of IEEE Std 1003.1-2004) - IEEE
               Standard for Information Technology - Portable Operating
-              System Interface (POSIX(R))",  IEEE Std 1003.1-2008, 2008,
+              System Interface (POSIX(R))", IEEE Std 1003.1-2008, 2008,
               <https://standards.ieee.org/findstds/
               standard/1003.1-2008.html>.
 
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119, DOI 10.17487/
+              RFC2119, March 1997, <https://www.rfc-editor.org/info/
+              rfc2119>.
 
 
 
 
 
-Brockners, et al.       Expires September 1, 2018              [Page 28]
+
+Brockners, et al.       Expires September 1, 2018              [Page 29]
 
 Internet-Draft           In-situ OAM Data Fields           February 2018
 
-
-   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
-              Requirement Levels", BCP 14, RFC 2119,
-              DOI 10.17487/RFC2119, March 1997, <https://www.rfc-
-              editor.org/info/rfc2119>.
 
    [RFC5905]  Mills, D., Martin, J., Ed., Burbank, J., and W. Kasch,
               "Network Time Protocol Version 4: Protocol and Algorithms
@@ -1616,20 +1667,20 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
               Network Virtualization Encapsulation", draft-ietf-
               nvo3-geneve-05 (work in progress), September 2017.
 
-
-
-
-
-
-Brockners, et al.       Expires September 1, 2018              [Page 29]
-
-Internet-Draft           In-situ OAM Data Fields           February 2018
-
-
    [I-D.ietf-nvo3-vxlan-gpe]
               Maino, F., Kreeger, L., and U. Elzur, "Generic Protocol
               Extension for VXLAN", draft-ietf-nvo3-vxlan-gpe-05 (work
               in progress), October 2017.
+
+
+
+
+
+
+Brockners, et al.       Expires September 1, 2018              [Page 30]
+
+Internet-Draft           In-situ OAM Data Fields           February 2018
+
 
    [I-D.ietf-sfc-nsh]
               Quinn, P., Elzur, U., and C. Pignataro, "Network Service
@@ -1647,9 +1698,9 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
               dataplane-probe-01 (work in progress), June 2016.
 
    [RFC7665]  Halpern, J., Ed. and C. Pignataro, Ed., "Service Function
-              Chaining (SFC) Architecture", RFC 7665,
-              DOI 10.17487/RFC7665, October 2015, <https://www.rfc-
-              editor.org/info/rfc7665>.
+              Chaining (SFC) Architecture", RFC 7665, DOI 10.17487/
+              RFC7665, October 2015, <https://www.rfc-editor.org/info/
+              rfc7665>.
 
    [RFC7799]  Morton, A., "Active and Passive Metrics and Methods (with
               Hybrid Types In-Between)", RFC 7799, DOI 10.17487/RFC7799,
@@ -1657,9 +1708,9 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
 
    [RFC7820]  Mizrahi, T., "UDP Checksum Complement in the One-Way
               Active Measurement Protocol (OWAMP) and Two-Way Active
-              Measurement Protocol (TWAMP)", RFC 7820,
-              DOI 10.17487/RFC7820, March 2016, <https://www.rfc-
-              editor.org/info/rfc7820>.
+              Measurement Protocol (TWAMP)", RFC 7820, DOI 10.17487/
+              RFC7820, March 2016, <https://www.rfc-editor.org/info/
+              rfc7820>.
 
    [RFC7821]  Mizrahi, T., "UDP Checksum Complement in the Network Time
               Protocol (NTP)", RFC 7821, DOI 10.17487/RFC7821, March
@@ -1677,7 +1728,12 @@ Authors' Addresses
 
 
 
-Brockners, et al.       Expires September 1, 2018              [Page 30]
+
+
+
+
+
+Brockners, et al.       Expires September 1, 2018              [Page 31]
 
 Internet-Draft           In-situ OAM Data Fields           February 2018
 
@@ -1733,7 +1789,7 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
 
 
 
-Brockners, et al.       Expires September 1, 2018              [Page 31]
+Brockners, et al.       Expires September 1, 2018              [Page 32]
 
 Internet-Draft           In-situ OAM Data Fields           February 2018
 
@@ -1789,4 +1845,4 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
 
 
 
-Brockners, et al.       Expires September 1, 2018              [Page 32]
+Brockners, et al.       Expires September 1, 2018              [Page 33]

--- a/drafts/versions/02/draft-ietf-ippm-ioam-data-02.txt
+++ b/drafts/versions/02/draft-ietf-ippm-ioam-data-02.txt
@@ -1127,7 +1127,7 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
     0                   1                   2                   3
     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-   |IOAM POT Type=0|P|IOAM POTFlags|           Reserved            |
+   |IOAM POT Type=0|P|R R R R R R R|           Reserved            |
    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+<-+
    |                           Random                              |  |
    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+  P
@@ -1144,16 +1144,15 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
       dictates the POT data that is included, to be set to 0 for the POT
       defined in this section.
 
-   IOAM POT flags:  8-bit.  Following flags are defined:
+   P bit:  1-bit.  "Profile-to-use" (P-bit) (most significant bit).
+      Indicates which POT-profile is used to generate the Cumulative.
+      Any node participating in POT will have a maximum of 2 profiles
+      configured that drive the computation of cumulative.  The two
+      profiles are numbered 0, 1.  This bit conveys whether profile 0 or
+      profile 1 is used to compute the Cumulative.
 
-      Bit 0  "Profile-to-use" (P-bit) (most significant bit).  Indicates
-         which POT-profile is used to generate the Cumulative.  Any node
-         participating in POT will have a maximum of 2 profiles
-         configured that drive the computation of cumulative.  The two
-         profiles are numbered 0, 1.  This bit conveys whether profile 0
-         or profile 1 is used to compute the Cumulative.
-
-      Bit 1-7  Reserved: Must be zero.
+   R (7 bits):  7-bit IOAM POT flags for future use.  MUST be zero on
+      transmission and ignored on receipt.
 
    Reserved:  16-bit Reserved bits are present for future use.  The
       reserved bits MUST be set to 0x0.
@@ -1169,6 +1168,7 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
    of space constraints in the transport protocol used).  Future
    versions of this document will address different sizes of data for
    "proof of transit".
+
 
 
 

--- a/drafts/versions/02/draft-ietf-ippm-ioam-data-02.txt
+++ b/drafts/versions/02/draft-ietf-ippm-ioam-data-02.txt
@@ -91,13 +91,13 @@ Table of Contents
        4.1.2.  IOAM node data fields and associated formats  . . . .  12
        4.1.3.  Examples of IOAM node data  . . . . . . . . . . . . .  17
      4.2.  IOAM Proof of Transit Option  . . . . . . . . . . . . . .  19
-       4.2.1.  IOAM Proof of Transit Type 0  . . . . . . . . . . . .  20
+       4.2.1.  IOAM Proof of Transit Type 0  . . . . . . . . . . . .  21
      4.3.  IOAM Edge-to-Edge Option  . . . . . . . . . . . . . . . .  22
    5.  Timestamp Formats . . . . . . . . . . . . . . . . . . . . . .  23
-     5.1.  PTP Truncated Timestamp Format  . . . . . . . . . . . . .  23
+     5.1.  PTP Truncated Timestamp Format  . . . . . . . . . . . . .  24
      5.2.  NTP 64-bit Timestamp Format . . . . . . . . . . . . . . .  25
      5.3.  POSIX-based Timestamp Format  . . . . . . . . . . . . . .  26
-   6.  IOAM Data Export  . . . . . . . . . . . . . . . . . . . . . .  27
+   6.  IOAM Data Export  . . . . . . . . . . . . . . . . . . . . . .  28
    7.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  28
      7.1.  Creation of a new In-Situ OAM  Protocol Parameters
            Registry (IOAM) Protocol Parameters IANA registry . . . .  28
@@ -115,7 +115,7 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
 
 
      7.7.  IOAM E2E Type Registry  . . . . . . . . . . . . . . . . .  29
-   8.  Manageability Considerations  . . . . . . . . . . . . . . . .  29
+   8.  Manageability Considerations  . . . . . . . . . . . . . . . .  30
    9.  Security Considerations . . . . . . . . . . . . . . . . . . .  30
    10. Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  30
    11. References  . . . . . . . . . . . . . . . . . . . . . . . . .  30
@@ -266,14 +266,14 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
 4.  IOAM Data Types and Formats
 
    This section defines IOAM data types and data fields and associated
-   data types required for IOAM.  The different uses of IOAM require the
-   definition of different types of data.  The IOAM data fields for the
-   data being carried corresponds to the three main categories of IOAM
-   data defined in [I-D.brockners-inband-oam-requirements], which are:
-   edge-to-edge, per node, and for selected nodes only.
+   data types required for IOAM.
 
-   Encapsulation options for IOAM data are outside the scope of this
-   memo, and are discussed in [I-D.brockners-inband-oam-transport].  A
+   To accommodate the different uses of IOAM, three main categories of
+   IOAM data are defined in [I-D.brockners-inband-oam-requirements],
+   which are: edge-to-edge, per node, and for selected nodes only.
+   Corresponding to these categories, IOAM data fields are encoded in
+   different IOAM options, each with its own definition of data types
+
 
 
 
@@ -282,13 +282,15 @@ Brockners, et al.       Expires September 1, 2018               [Page 5]
 Internet-Draft           In-situ OAM Data Fields           February 2018
 
 
-   bit field determines the set of OAM data fields embedded in a packet.
-   Depending on the type of the encapsulation, a type and length field
-   indicates type and length of the data fields that are included in a
-   particular packet.  For the encapsulations where IOAM uses its own
-   name space to distinguish between the various data type options
-   defined in this section, IOAM-Type registry is defined with the
-   following code points to identify the IOAM options:
+   and data fields.  In many cases, a bit field determines the set of
+   IOAM data fields embedded in that IOAM option in the packet.
+
+   Encapsulation options for IOAM data are outside the scope of this
+   memo, and are discussed in [I-D.brockners-inband-oam-transport].  One
+   exception is for encapsulations where IOAM uses its own name space to
+   distinguish between the IOAM options.  For these encapsulations, a
+   common IOAM-Type registry is defined, with the following code points
+   to identify the IOAM options:
 
    0  IOAM Pre-allocated Trace Option Type
 
@@ -328,8 +330,6 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
    not all nodes within a domain are IOAM capable, IOAM tracing
    information will only be collected on those nodes which are IOAM
    capable.  Nodes which are not IOAM capable will forward the packet
-   without any changes to the IOAM data fields.  The maximum number of
-
 
 
 
@@ -338,6 +338,7 @@ Brockners, et al.       Expires September 1, 2018               [Page 6]
 Internet-Draft           In-situ OAM Data Fields           February 2018
 
 
+   without any changes to the IOAM data fields.  The maximum number of
    hops and the minimum path MTU of the IOAM domain is assumed to be
    known.
 
@@ -385,7 +386,6 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
    Every node data entry is to hold information for a particular IOAM
    transit node that is traversed by a packet.  The in-situ OAM
    decapsulating node removes the IOAM data and processes and/or exports
-   the metadata.  IOAM data uses its own name-space for information such
 
 
 
@@ -394,6 +394,7 @@ Brockners, et al.       Expires September 1, 2018               [Page 7]
 Internet-Draft           In-situ OAM Data Fields           February 2018
 
 
+   the metadata.  IOAM data uses its own name-space for information such
    as node identifier or interface identifier.  This allows for a
    domain-specific definition and interpretation.  For example: In one
    case an interface-id could point to a physical interface (e.g., to
@@ -440,8 +441,7 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
 
    The in-situ OAM pre-allocated trace option and the in-situ OAM
    incremental trace option have similar formats.  Except where noted
-   below, the internal formats and fields of the two trace options are
-   identical.
+
 
 
 
@@ -449,6 +449,9 @@ Brockners, et al.       Expires September 1, 2018               [Page 8]
 
 Internet-Draft           In-situ OAM Data Fields           February 2018
 
+
+   below, the internal formats and fields of the two trace options are
+   identical.
 
    Pre-allocated and incremental trace option headers:
 
@@ -494,9 +497,6 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
       Bit 0    (Most significant bit) When set indicates presence of
                Hop_Lim and node_id in the node data.
 
-      Bit 1    When set indicates presence of ingress_if_id and
-               egress_if_id (short format) in the node data.
-
 
 
 
@@ -505,6 +505,9 @@ Brockners, et al.       Expires September 1, 2018               [Page 9]
 
 Internet-Draft           In-situ OAM Data Fields           February 2018
 
+
+      Bit 1    When set indicates presence of ingress_if_id and
+               egress_if_id (short format) in the node data.
 
       Bit 2    When set indicates presence of timestamp seconds in the
                node data.
@@ -550,10 +553,7 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
                2.  Not add any node data fields to the packet, even for
                    the IOAM-Trace-Type bits defined above.
 
-      Section 4.1.2 describes the IOAM data types and their formats.
-      Within an in-situ OAM domain possible combinations of these bits
-      making the IOAM-Trace-Type can be restricted by configuration
-      knobs.
+
 
 
 
@@ -561,6 +561,11 @@ Brockners, et al.       Expires September 1, 2018              [Page 10]
 
 Internet-Draft           In-situ OAM Data Fields           February 2018
 
+
+      Section 4.1.2 describes the IOAM data types and their formats.
+      Within an in-situ OAM domain possible combinations of these bits
+      making the IOAM-Trace-Type can be restricted by configuration
+      knobs.
 
    NodeLen:  5-bit unsigned integer.  This field specifies the length of
       data added by each node in multiples of 4-octets, excluding the
@@ -605,11 +610,6 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
          in the copied packet.  The address of the node performing the
          copy operation is used as the source address.  The L-bit MUST
          be cleared in the copy of the packet that a node sends back
-         towards the source.  On its way back towards the source, the
-         packet is processed like a regular packet with IOAM
-         information.  Once the return packet reaches the IOAM domain
-         boundary IOAM decapsulation occurs as with any other packet
-         containing IOAM information.
 
 
 
@@ -617,6 +617,12 @@ Brockners, et al.       Expires September 1, 2018              [Page 11]
 
 Internet-Draft           In-situ OAM Data Fields           February 2018
 
+
+         towards the source.  On its way back towards the source, the
+         packet is processed like a regular packet with IOAM
+         information.  Once the return packet reaches the IOAM domain
+         boundary IOAM decapsulation occurs as with any other packet
+         containing IOAM information.
 
       Bit 2-3  Reserved: Must be zero.
 
@@ -660,12 +666,6 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
 
    Hop_Lim and node_id:  4-octet field defined as follows:
 
-    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-   |   Hop_Lim     |              node_id                          |
-   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-
-
 
 
 
@@ -673,6 +673,11 @@ Brockners, et al.       Expires September 1, 2018              [Page 12]
 
 Internet-Draft           In-situ OAM Data Fields           February 2018
 
+
+    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |   Hop_Lim     |              node_id                          |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 
       Hop_Lim:  1-octet unsigned integer.  It is set to the Hop Limit
          value in the packet at the node that records this data.  Hop
@@ -717,11 +722,6 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
       value to its own time-of-day in order to detect the error
       indication.
 
-   timestamp subseconds:  4-octet unsigned integer.  Absolute timestamp
-      in subseconds that specifies the time at which the packet was
-      received by the node.  This field has three possible formats;
-      based on either PTP [IEEE1588v2], NTP [RFC5905], or POSIX [POSIX].
-      The three timestamp formats are specified in Section 5.  In all
 
 
 
@@ -730,6 +730,11 @@ Brockners, et al.       Expires September 1, 2018              [Page 13]
 Internet-Draft           In-situ OAM Data Fields           February 2018
 
 
+   timestamp subseconds:  4-octet unsigned integer.  Absolute timestamp
+      in subseconds that specifies the time at which the packet was
+      received by the node.  This field has three possible formats;
+      based on either PTP [IEEE1588v2], NTP [RFC5905], or POSIX [POSIX].
+      The three timestamp formats are specified in Section 5.  In all
       three cases, the Timestamp Subseconds field contains the 32 least
       significant bits of the timestamp format that is specified in
       Section 5.  If a node is not capable of populating this field, it
@@ -770,14 +775,9 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
       queue (a packet may consume one or more memory buffers, depending
       on its size).
 
-    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-   |                       queue depth                             |
-   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 
-   Opaque State Snapshot:  Variable length field.  It allows the network
-      element to store an arbitrary state in the node data field ,
-      without a pre-defined schema.  The schema needs to be made known
+
+
 
 
 
@@ -786,6 +786,14 @@ Brockners, et al.       Expires September 1, 2018              [Page 14]
 Internet-Draft           In-situ OAM Data Fields           February 2018
 
 
+    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |                       queue depth                             |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+   Opaque State Snapshot:  Variable length field.  It allows the network
+      element to store an arbitrary state in the node data field ,
+      without a pre-defined schema.  The schema needs to be made known
       to the analyzer by some out-of-band mechanism.  The specification
       of this mechanism is beyond the scope of this document.  The
       24-bit "Schema Id" field in the field indicates which particular
@@ -821,6 +829,19 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
 
    Hop_Lim and node_id wide:  8-octet field defined as follows:
 
+
+
+
+
+
+
+
+
+Brockners, et al.       Expires September 1, 2018              [Page 15]
+
+Internet-Draft           In-situ OAM Data Fields           February 2018
+
+
     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
    |   Hop_Lim     |              node_id                          ~
@@ -834,14 +855,6 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
          in the communication path.  This is copied from the lower layer
          for e.g.  TTL value in IPv4 header or hop limit field from IPv6
          header of the packet.  The semantics of the Hop_Lim field
-
-
-
-Brockners, et al.       Expires September 1, 2018              [Page 15]
-
-Internet-Draft           In-situ OAM Data Fields           February 2018
-
-
          depend on the lower layer protocol that IOAM is encapsulated
          over, and therefore its specific semantics are outside the
          scope of this memo.
@@ -872,6 +885,19 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
       format" 8-octed bit field with its semantics defined by a specific
       deployment.
 
+
+
+
+
+
+
+
+
+Brockners, et al.       Expires September 1, 2018              [Page 16]
+
+Internet-Draft           In-situ OAM Data Fields           February 2018
+
+
     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
    |                       app data                                ~
@@ -889,14 +915,6 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
       node adding node data MUST carry out one of the following two
       alternatives in order to maintain the correctness of the UDP
       Checksum value:
-
-
-
-
-Brockners, et al.       Expires September 1, 2018              [Page 16]
-
-Internet-Draft           In-situ OAM Data Fields           February 2018
-
 
       1.  Recompute the UDP Checksum field.
 
@@ -929,6 +947,13 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
 
    0xD400:  IOAM-Trace-Type is 0xD400 then the format of node data is:
 
+
+
+Brockners, et al.       Expires September 1, 2018              [Page 17]
+
+Internet-Draft           In-situ OAM Data Fields           February 2018
+
+
         0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
        +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
        |   Hop_Lim     |              node_id                          |
@@ -943,16 +968,6 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
 
 
    0xC000:  IOAM-Trace-Type is 0xC000 then the format is:
-
-
-
-
-
-
-Brockners, et al.       Expires September 1, 2018              [Page 17]
-
-Internet-Draft           In-situ OAM Data Fields           February 2018
-
 
         0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
        +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -984,6 +999,17 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
 
    0x9400:  IOAM-Trace-Type is 0x9400 then the format is:
 
+
+
+
+
+
+
+Brockners, et al.       Expires September 1, 2018              [Page 18]
+
+Internet-Draft           In-situ OAM Data Fields           February 2018
+
+
         0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
        +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
        |   Hop_Lim     |              node_id                          |
@@ -995,20 +1021,6 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
 
 
    0x3180:  IOAM-Trace-Type is 0x3180 then the format is:
-
-
-
-
-
-
-
-
-
-
-Brockners, et al.       Expires September 1, 2018              [Page 18]
-
-Internet-Draft           In-situ OAM Data Fields           February 2018
-
 
         0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
        +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -1045,18 +1057,6 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
    Correspondingly, two pieces of information are added as IOAM data to
    the packet:
 
-   o  Random: Unique identifier for the packet (e.g., 64-bits allow for
-      the unique identification of 2^64 packets).
-
-   o  Cumulative: Information which is handed from node to node and
-      updated by every node according to a verification algorithm.
-
-
-
-
-
-
-
 
 
 
@@ -1065,6 +1065,12 @@ Brockners, et al.       Expires September 1, 2018              [Page 19]
 
 Internet-Draft           In-situ OAM Data Fields           February 2018
 
+
+   o  Random: Unique identifier for the packet (e.g., 64-bits allow for
+      the unique identification of 2^64 packets).
+
+   o  Cumulative: Information which is handed from node to node and
+      updated by every node according to a verification algorithm.
 
    IOAM proof of transit option:
 
@@ -1078,11 +1084,11 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
 
    IOAM proof of transit option data MUST be 4-octet aligned.:
 
-     0                   1                   2                   3
-     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    |       POT Option data field determined by IOAM-POT-Type       ~
-    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    0                   1                   2                   3
+    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |       POT Option data field determined by IOAM-POT-Type       |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 
 
 
@@ -1094,26 +1100,20 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
 
    IOAM POT flags:  8-bit.  Following flags are defined:
 
-      Bit 0  "Profile-to-use" (P-bit) (most significant bit).  Indicates
-         which POT-profile is used by POT Type 0.
+      Bit 0  "Profile-to-use" (P-bit) (most significant bit).  For IOAM
+         POT types that use a maximum of two profiles to drive
+         computation, indicates which POT-profile is used.  The two
+         profiles are numbered 0, 1.
 
-      Bit 1-7  Reserved: Must be zero.
+      Bit 1-7  Reserved: Must be set to zero upon transmission and
+         ignored upon receipt.
 
    Reserved:  16-bit Reserved bits are present for future use.  The
-      reserved bits MUST be set to 0x0.
+      reserved bits Must be set to zero upon transmission and ignored
+      upon receipt.
 
    POT Option data:  Variable-length field.  The type of which is
       determined by the IOAM-POT-Type.
-
-4.2.1.  IOAM Proof of Transit Type 0
-
-
-
-
-
-
-
-
 
 
 
@@ -1121,6 +1121,8 @@ Brockners, et al.       Expires September 1, 2018              [Page 20]
 
 Internet-Draft           In-situ OAM Data Fields           February 2018
 
+
+4.2.1.  IOAM Proof of Transit Type 0
 
    IOAM proof of transit option of IOAM POT Type 0:
 
@@ -1141,8 +1143,8 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
 
 
    IOAM POT Type:  8-bit identifier of a particular POT variant that
-      dictates the POT data that is included, to be set to 0 for the POT
-      defined in this section.
+      dictates the POT data that is included.  This section defines the
+      POT data when the IOAM POT Type is set to the value 0.
 
    P bit:  1-bit.  "Profile-to-use" (P-bit) (most significant bit).
       Indicates which POT-profile is used to generate the Cumulative.
@@ -1151,11 +1153,12 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
       profiles are numbered 0, 1.  This bit conveys whether profile 0 or
       profile 1 is used to compute the Cumulative.
 
-   R (7 bits):  7-bit IOAM POT flags for future use.  MUST be zero on
-      transmission and ignored on receipt.
+   R (7 bits):  7-bit IOAM POT flags for future use.  MUST be set to
+      zero upon transmission and ignored upon receipt.
 
    Reserved:  16-bit Reserved bits are present for future use.  The
-      reserved bits MUST be set to 0x0.
+      reserved bits Must be set to zero upon transmission and ignored
+      upon receipt.
 
    Random:  64-bit Per packet Random number.
 
@@ -1166,9 +1169,6 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
    Note: Larger or smaller sizes of "Random" and "Cumulative" data are
    feasible and could be required for certain deployments (e.g. in case
    of space constraints in the transport protocol used).  Future
-   versions of this document will address different sizes of data for
-   "proof of transit".
-
 
 
 
@@ -1177,6 +1177,9 @@ Brockners, et al.       Expires September 1, 2018              [Page 21]
 
 Internet-Draft           In-situ OAM Data Fields           February 2018
 
+
+   versions of this document will address different sizes of data for
+   "proof of transit".
 
 4.3.  IOAM Edge-to-Edge Option
 
@@ -1194,8 +1197,8 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
 
       IOAM edge-to-edge option header:
 
-      0                   1                   2                   3
-      0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+       0                   1                   2                   3
+       0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
       |         IOAM-E2E-Type         |             Reserved          |
       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -1209,8 +1212,9 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 
 
-   IOAM-E2E-Type:  16-bit identifier of a particular in situ OAM E2E
-      variant.  The order of packing the E2E option data field elements
+   IOAM-E2E-Type:  A 16-bit identifier which specifies which data types
+      are used in the E2E option data.  The IOAM-E2E-Type value is a bit
+      field.  The order of packing the E2E option data field elements
       follows the bit order of the IOAM-E2E-Type field, as follows:
 
       Bit 0    (Most significant bit) When set indicates presence of a
@@ -1222,10 +1226,6 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
                added to a specific tube which is used to identify packet
                loss and reordering for that tube.
 
-      Bit 2    When set indicates presence of timestamp seconds for the
-               transmission of the frame.  This 4-octet field has three
-               possible formats; based on either PTP [IEEE1588v2], NTP
-               [RFC5905], or POSIX [POSIX].  The three timestamp formats
 
 
 
@@ -1234,6 +1234,10 @@ Brockners, et al.       Expires September 1, 2018              [Page 22]
 Internet-Draft           In-situ OAM Data Fields           February 2018
 
 
+      Bit 2    When set indicates presence of timestamp seconds for the
+               transmission of the frame.  This 4-octet field has three
+               possible formats; based on either PTP [IEEE1588v2], NTP
+               [RFC5905], or POSIX [POSIX].  The three timestamp formats
                are specified in Section 5.  In all three cases, the
                Timestamp Seconds field contains the 32 most significant
                bits of the timestamp format that is specified in
@@ -1258,11 +1262,13 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
                If the NTP format is used the analyzer should correlate
                several packets in order to detect the error indication.
 
-      Bit 4-15 Undefined.  An IOAM encapsulating node must set the value
-               of each of these bits to 0.
+      Bit 4-15 Undefined.  An IOAM encapsulating node Must set the value
+               of these bits to zero upon transmission and ignore upon
+               receipt.
 
    Reserved:  16-bits Reserved bits are present for future use.  The
-      reserved bits MUST be set to 0x0.
+      reserved bits Must be set to zero upon transmission and ignored
+      upon receipt.
 
    E2E Option data:  Variable-length field.  The type of which is
       determined by the IOAM-E2E-Type.
@@ -1274,6 +1280,16 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
    management plane is responsible for determining which timestamp
    format is used.
 
+
+
+
+
+
+Brockners, et al.       Expires September 1, 2018              [Page 23]
+
+Internet-Draft           In-situ OAM Data Fields           February 2018
+
+
 5.1.  PTP Truncated Timestamp Format
 
    The Precision Time Protocol (PTP) [IEEE1588v2] uses an 80-bit
@@ -1282,12 +1298,6 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
    The PTP truncated format is specified in Section 4.3 of
    [I-D.ietf-ntp-packet-timestamps], and the details are presented below
    for the sake of completeness.
-
-
-
-Brockners, et al.       Expires September 1, 2018              [Page 23]
-
-Internet-Draft           In-situ OAM Data Fields           February 2018
 
 
         0                   1                   2                   3
@@ -1328,6 +1338,14 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
 
    Wraparound:
 
+
+
+
+Brockners, et al.       Expires September 1, 2018              [Page 24]
+
+Internet-Draft           In-situ OAM Data Fields           February 2018
+
+
       This time format wraps around every 2^32 seconds, which is roughly
       136 years.  The next wraparound will occur in the year 2106.
 
@@ -1337,15 +1355,6 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
       among themselves.  Nodes may be synchronized to a global reference
       time.  Note that if PTP [IEEE1588v2] is used for synchronization,
       the timestamp may be derived from the PTP-synchronized clock,
-
-
-
-
-Brockners, et al.       Expires September 1, 2018              [Page 24]
-
-Internet-Draft           In-situ OAM Data Fields           February 2018
-
-
       allowing the timestamp to be measured with respect to the clock of
       an PTP Grandmaster clock.
 
@@ -1384,6 +1393,15 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
 
       + Size: 32 bits.
 
+
+
+
+
+Brockners, et al.       Expires September 1, 2018              [Page 25]
+
+Internet-Draft           In-situ OAM Data Fields           February 2018
+
+
       + Units: the unit is 2^(-32) seconds, which is roughly equal to
       233 picoseconds.
 
@@ -1394,13 +1412,6 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
    Resolution:
 
       The resolution is 2^(-32) seconds.
-
-
-
-Brockners, et al.       Expires September 1, 2018              [Page 25]
-
-Internet-Draft           In-situ OAM Data Fields           February 2018
-
 
    Wraparound:
 
@@ -1439,6 +1450,14 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
 
    Timestamp field format:
 
+
+
+
+Brockners, et al.       Expires September 1, 2018              [Page 26]
+
+Internet-Draft           In-situ OAM Data Fields           February 2018
+
+
       Seconds: specifies the integer portion of the number of seconds
       since the epoch.
 
@@ -1450,13 +1469,6 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
       seconds since the epoch.
 
       + Size: 32 bits.
-
-
-
-Brockners, et al.       Expires September 1, 2018              [Page 26]
-
-Internet-Draft           In-situ OAM Data Fields           February 2018
-
 
       + Units: the unit is microseconds.  The value of this field is in
       the range 0 to (10^6)-1.
@@ -1491,18 +1503,6 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
       a timestamp during or slightly after a leap second may be
       temporarily inaccurate.
 
-6.  IOAM Data Export
-
-   IOAM nodes collect information for packets traversing a domain that
-   supports IOAM.  IOAM decapsulating nodes as well as IOAM transit
-   nodes can choose to retrieve IOAM information from the packet,
-   process the information further and export the information using
-   e.g., IPFIX.
-
-   The discussion of IOAM data processing and export is left for a
-   future version of this document.
-
-
 
 
 
@@ -1513,6 +1513,17 @@ Brockners, et al.       Expires September 1, 2018              [Page 27]
 
 Internet-Draft           In-situ OAM Data Fields           February 2018
 
+
+6.  IOAM Data Export
+
+   IOAM nodes collect information for packets traversing a domain that
+   supports IOAM.  IOAM decapsulating nodes as well as IOAM transit
+   nodes can choose to retrieve IOAM information from the packet,
+   process the information further and export the information using
+   e.g., IPFIX.
+
+   The discussion of IOAM data processing and export is left for a
+   future version of this document.
 
 7.  IANA Considerations
 
@@ -1546,11 +1557,18 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
 
 7.2.  IOAM Type Registry
 
-   This registry defines 128 code points to define IOAM-Type field for
+   This registry defines 128 code points for the IOAM-Type field for
    identifying IOAM options as explained in Section 4.  The following
    code points are defined in this draft:
 
    0  IOAM Pre-allocated Trace Option Type
+
+
+
+Brockners, et al.       Expires September 1, 2018              [Page 28]
+
+Internet-Draft           In-situ OAM Data Fields           February 2018
+
 
    1  IOAM Incremental Trace Option Type
 
@@ -1560,15 +1578,6 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
 
    4 - 127 are available for assignment via RFC Required process as per
    [RFC8126].
-
-
-
-
-
-Brockners, et al.       Expires September 1, 2018              [Page 28]
-
-Internet-Draft           In-situ OAM Data Fields           February 2018
-
 
 7.3.  IOAM Trace Type Registry
 
@@ -1610,21 +1619,17 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
    - 3 are defined in this document.  The meaning of Bit 4 - 15 are
    available for assignments via RFC Required process as per [RFC8126].
 
-8.  Manageability Considerations
-
-   Manageability considerations will be addressed in a later version of
-   this document..
-
-
-
-
-
 
 
 Brockners, et al.       Expires September 1, 2018              [Page 29]
 
 Internet-Draft           In-situ OAM Data Fields           February 2018
 
+
+8.  Manageability Considerations
+
+   Manageability considerations will be addressed in a later version of
+   this document..
 
 9.  Security Considerations
 
@@ -1667,11 +1672,6 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
               <https://standards.ieee.org/findstds/
               standard/1003.1-2008.html>.
 
-   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
-              Requirement Levels", BCP 14, RFC 2119, DOI 10.17487/
-              RFC2119, March 1997, <https://www.rfc-editor.org/info/
-              rfc2119>.
-
 
 
 
@@ -1681,6 +1681,11 @@ Brockners, et al.       Expires September 1, 2018              [Page 30]
 
 Internet-Draft           In-situ OAM Data Fields           February 2018
 
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119, DOI 10.17487/
+              RFC2119, March 1997, <https://www.rfc-editor.org/info/
+              rfc2119>.
 
    [RFC5905]  Mills, D., Martin, J., Ed., Burbank, J., and W. Kasch,
               "Network Time Protocol Version 4: Protocol and Algorithms
@@ -1723,11 +1728,6 @@ Internet-Draft           In-situ OAM Data Fields           February 2018
               Network Virtualization Encapsulation", draft-ietf-
               nvo3-geneve-05 (work in progress), September 2017.
 
-   [I-D.ietf-nvo3-vxlan-gpe]
-              Maino, F., Kreeger, L., and U. Elzur, "Generic Protocol
-              Extension for VXLAN", draft-ietf-nvo3-vxlan-gpe-05 (work
-              in progress), October 2017.
-
 
 
 
@@ -1737,6 +1737,11 @@ Brockners, et al.       Expires September 1, 2018              [Page 31]
 
 Internet-Draft           In-situ OAM Data Fields           February 2018
 
+
+   [I-D.ietf-nvo3-vxlan-gpe]
+              Maino, F., Kreeger, L., and U. Elzur, "Generic Protocol
+              Extension for VXLAN", draft-ietf-nvo3-vxlan-gpe-05 (work
+              in progress), October 2017.
 
    [I-D.ietf-sfc-nsh]
               Quinn, P., Elzur, U., and C. Pignataro, "Network Service
@@ -1781,11 +1786,6 @@ Authors' Addresses
    Germany
 
    Email: fbrockne@cisco.com
-
-
-
-
-
 
 
 


### PR DESCRIPTION
Defines the subtype field in a 4 octet header for POT and E2E
Fixes #78
Expands E2E subtype to 16bits