### PR TITLE
Use IOAM Type in IPv6 encap

### DIFF
--- a/drafts/draft-ioametal-ippm-6man-ioam-ipv6-options.xml
+++ b/drafts/draft-ioametal-ippm-6man-ioam-ipv6-options.xml
@@ -194,11 +194,11 @@
 
       <address>
         <postal>
-          <street>2185 Park Boulevard</street>
+          <street>4750 Patrick Henry Drive</street>
 
-          <city>Palo Alto, CA</city>
+          <city>Santa Clara, CA</city>
 
-          <code>94306</code>
+          <code>95054</code>
 
           <country>US</country>
         </postal>
@@ -264,22 +264,22 @@
     </section>
 
     <section title="In-situ OAM Metadata Transport in IPv6">
-      <t>An IPv6 option is defined corresponding to each of the IOAM data
-      fields defined in <xref target="I-D.ietf-ippm-ioam-data"></xref>. This
-      mechanisms of in-situ OAM in IPv6 is used to enhance diagnostics of IPv6
-      networks. It complements other mechanisms proposed to enhance
-      diagnostics of IPv6 networks, such as the IPv6 Performance and
-      Diagnostic Metrics Destination Option described in <xref
-      target="RFC8250"></xref>. IOAM data is carried in IPv6 packets as
-      Hop-by-Hop or Destination options as specified in the individual option
-      definition below.</t>
+      <t>IOAM data is carried in IPv6 packets as Hop-by-Hop or Destination
+      options. One IPv6 Destination Options and Hop-by-Hop Options Type
+      codepoint is assigned for IOAM. Multiple options with the same Option
+      Type MAY appear in the same Hop-by-Hop Options or Destination Options
+      header, with varying content. This mechanism of in-situ OAM in IPv6 is
+      used to enhance diagnostics of IPv6 networks. It complements other
+      mechanisms proposed to enhance diagnostics of IPv6 networks, such as the
+      IPv6 Performance and Diagnostic Metrics Destination Option described in
+      <xref target="RFC8250"></xref>.</t>
 
-      <t>IPv6 hop-by-hop and destination option format for carrying in-situ
+      <t>IPv6 Hop-by-Hop and Destination Option format for carrying in-situ
       OAM data fields:<figure>
           <artwork><![CDATA[
 
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|  Option Type  |  Opt Data Len |         Reserved (MBZ)        |
+|  Option Type  |  Opt Data Len |   Reserved    |   IOAM Type   |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+<-+
 |                                                               |  |
 .                                                               .  I
@@ -297,62 +297,74 @@
 |                                                               |  |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+<-+
 
-Option Type          8-bit identifier of the type of option.
-
-Opt Data Len         8-bit unsigned integer.  Length of the
-                     Reserved and Option Data field of this option,
-                     in octets.
-
-Reserved (MBZ)       16-bit field MUST be filled with zeroes.
-
-Option Data          Variable-length field.  Option-Type-specific
-                     data.
-
 ]]></artwork>
         </figure></t>
+
+        <t><list style="hanging">
+            <t hangText="Option Type:">8-bit identifier of the type of
+            option.</t>
+
+            <t hangText="Opt Data Len:">8-bit unsigned integer.  Length of the
+            Reserved and Option Data field of this option, in octets.</t>
+
+            <t hangText="Reserved:">8-bit field MUST be set to zero upon
+            transmission and ignored upon reception.</t>
+
+            <t hangText="IOAM Type:">8-bit field as defined in section 7.2 in
+            <xref target="I-D.ietf-ippm-ioam-data"></xref>.</t>
+
+            <t hangText="Option Data:">Variable-length field.
+            Option-Type-specific data.</t>
+        </list></t>
 
       <t>In-situ OAM Options are inserted as Option data as follows:<list
           style="numbers">
           <t>Pre-allocated Tracing Option: The in-situ OAM Preallocated
           Tracing option defined in <xref
           target="I-D.ietf-ippm-ioam-data"></xref> is represented as a IPv6
-          option in hop by hop extension header by allocating following type:
+          option in hop by hop extension header:
           <list style="hanging">
-              <t hangText="Option Type:">001xxxxxx 8-bit identifier of the
-              type of option. xxxxxx=TBD1.</t>
+              <t hangText="Option Type:">001xxxxx 8-bit identifier of the
+              IOAM type of option. xxxxx=TBD.</t>
+              <t hangText="IOAM Type:">IOAM Pre-allocated Trace Option
+              Type.</t>
             </list></t>
 
           <t>Incremental Tracing Option: The in-situ OAM Incremental Tracing
           option defined in <xref target="I-D.ietf-ippm-ioam-data"></xref> is
-          represented as a IPv6 option in hop by hop extension header by
-          allocating following type: <list style="hanging">
-              <t hangText="Option Type:">001xxxxxx 8-bit identifier of the
-              type of option. xxxxxx=TBD2.</t>
+          represented as a IPv6 option in hop by hop extension header:
+          <list style="hanging">
+              <t hangText="Option Type:">001xxxxx 8-bit identifier of the
+              IOAM type of option. xxxxx=TBD.</t>
+              <t hangText="IOAM Type:">IOAM Incremental Trace Option Type.</t>
             </list></t>
 
           <t>Proof of Transit Option: The in-situ OAM POT option defined in
           <xref target="I-D.ietf-ippm-ioam-data"></xref> is represented as a
-          IPv6 option in hop by hop extension header by allocating following
-          type: <list style="hanging">
-              <t hangText="Option Type:">001xxxxxx 8-bit identifier of the
-              type of option. xxxxxx=TBD3.</t>
+          IPv6 option in hop by hop extension header:
+          <list style="hanging">
+              <t hangText="Option Type:">001xxxxx 8-bit identifier of the
+              IOAM type of option. xxxxx=TBD.</t>
+              <t hangText="IOAM Type:">IOAM POT Option Type.</t>
             </list></t>
 
           <t>Edge to Edge Option: The in-situ OAM E2E option defined in <xref
           target="I-D.ietf-ippm-ioam-data"></xref> is represented as a IPv6
-          option in IPv6 option in destination options extension header by
-          allocating following type: <list style="hanging">
-              <t hangText="Option Type:">000xxxxxx 8-bit identifier of the
-              type of option. xxxxxx=TBD4.</t>
+          option in IPv6 option in destination options extension header:
+          <list style="hanging">
+              <t hangText="Option Type:">000xxxxx 8-bit identifier of the
+              IOAM type of option. xxxxx=TBD.</t>
+              <t hangText="IOAM Type:">IOAM E2E Option Type.</t>
             </list></t>
         </list>All the in-situ OAM IPv6 options defined here have alignment
-      requirement. Following the convention in IPv6, these options are aligned
-      in a packet so that multi-octet values within the Option Data field of
-      each option are 4-octet aligned as specified in <xref
-      target="I-D.ietf-ippm-ioam-data"></xref>. In addition, to maintain IPv6
-      extenstion header 8-octet alignment requirement, Trace-Type for
-      Incremental Tracing Option in IPv6 MUST be selected such that the IOAM
-      node data length is a multiple of 8-octets.</t>
+      requirements. Specifically, they all require 4n alignment. This ensures
+      that 4 octet fields specified in
+      <xref target="I-D.ietf-ippm-ioam-data"></xref> such as transit delay are
+      aligned at a multiple-of-4 offset from the start of the Hop-by-Hop
+      Options header. In addition, to maintain IPv6 extension header 8-octet
+      alignment and avoid the need to add or remove padding at every hop, the
+      Trace-Type for Incremental Tracing Option in IPv6 MUST be selected such
+      that the IOAM node data length is a multiple of 8-octets.</t>
     </section>
 
     <section title="Security Considerations">
@@ -379,14 +391,8 @@ Option Data          Variable-length field.  Option-Type-specific
    Hex Value    Binary Value      Description           Reference
                 act chg rest
    ----------------------------------------------------------------
-   TBD_1        00   1   TBD1   IOAM Pre-allocated      [This draft]
-                                Tracing Option
-   TBD_2        00   1   TBD2   IOAM Incremental        [This draft]
-                                Tracing Option
-   TBD_3        00   1   TBD3   IOAM Proof of Transit   [This draft]
-                                Option
-   TBD_4        00   0   TBD4   IOAM Edge to Edge       [This draft]
-                                Option
+   TBD_1_0      00   0  TBD_1     IOAM                  [This draft]
+   TBD_1_1      00   1  TBD_1     IOAM                  [This draft]
 ]]></artwork>
         </figure></t>
     </section>

--- a/drafts/versions/01/draft-ioametal-ippm-6man-ioam-ipv6-options-01.txt
+++ b/drafts/versions/01/draft-ioametal-ippm-6man-ioam-ipv6-options-01.txt
@@ -1,0 +1,448 @@
+
+
+
+
+ippm,6man                                                    S. Bhandari
+Internet-Draft                                              F. Brockners
+Intended status: Standards Track                            C. Pignataro
+Expires: December 31, 2018                                         Cisco
+                                                              H. Gredler
+                                                            RtBrick Inc.
+                                                                J. Leddy
+                                                                 Comcast
+                                                               S. Youell
+                                                                    JMPC
+                                                              T. Mizrahi
+                                                                 Marvell
+                                                                 A. Kfir
+                                                                B. Gafni
+                                             Mellanox Technologies, Inc.
+                                                             P. Lapukhov
+                                                                Facebook
+                                                              M. Spiegel
+                                                       Barefoot Networks
+                                                             S. Krishnan
+                                                                  Kaloom
+                                                           June 29, 2018
+
+
+                        In-situ OAM IPv6 Options
+             draft-ioametal-ippm-6man-ioam-ipv6-options-00
+
+Abstract
+
+   In-situ Operations, Administration, and Maintenance (IOAM) records
+   operational and telemetry information in the packet while the packet
+   traverses a path between two points in the network.  This document
+   outlines how IOAM data fields are encapsulated in IPv6.
+
+Status of This Memo
+
+   This Internet-Draft is submitted in full conformance with the
+   provisions of BCP 78 and BCP 79.
+
+   Internet-Drafts are working documents of the Internet Engineering
+   Task Force (IETF).  Note that other groups may also distribute
+   working documents as Internet-Drafts.  The list of current Internet-
+   Drafts is at https://datatracker.ietf.org/drafts/current/.
+
+   Internet-Drafts are draft documents valid for a maximum of six months
+   and may be updated, replaced, or obsoleted by other documents at any
+   time.  It is inappropriate to use Internet-Drafts as reference
+   material or to cite them other than as "work in progress."
+
+
+
+Bhandari, et al.        Expires December 31, 2018               [Page 1]
+
+Internet-Draft       In-situ OAM IPv6 encapsulation            June 2018
+
+
+   This Internet-Draft will expire on December 31, 2018.
+
+Copyright Notice
+
+   Copyright (c) 2018 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (https://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+Table of Contents
+
+   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   2
+   2.  Conventions . . . . . . . . . . . . . . . . . . . . . . . . .   2
+     2.1.  Requirements Language . . . . . . . . . . . . . . . . . .   2
+     2.2.  Abbreviations . . . . . . . . . . . . . . . . . . . . . .   3
+   3.  In-situ OAM Metadata Transport in IPv6  . . . . . . . . . . .   3
+   4.  Security Considerations . . . . . . . . . . . . . . . . . . .   5
+   5.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   5
+   6.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .   5
+   7.  References  . . . . . . . . . . . . . . . . . . . . . . . . .   6
+     7.1.  Normative References  . . . . . . . . . . . . . . . . . .   6
+     7.2.  Informative References  . . . . . . . . . . . . . . . . .   6
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .   6
+
+1.  Introduction
+
+   In-situ Operations, Administration, and Maintenance (IOAM) records
+   operational and telemetry information in the packet while the packet
+   traverses a path between two points in the network.  This document
+   outlines how IOAM data fields are encapsulated in the IPv6 [RFC8200].
+
+2.  Conventions
+
+2.1.  Requirements Language
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and
+   "OPTIONAL" in this document are to be interpreted as described in BCP
+   14 [RFC2119] [RFC8174] when, and only when, they appear in all
+   capitals, as shown here.
+
+
+
+Bhandari, et al.        Expires December 31, 2018               [Page 2]
+
+Internet-Draft       In-situ OAM IPv6 encapsulation            June 2018
+
+
+2.2.  Abbreviations
+
+   Abbreviations used in this document:
+
+   E2E:       Edge-to-Edge
+
+   IOAM:      In-situ Operations, Administration, and Maintenance
+
+   OAM:       Operations, Administration, and Maintenance
+
+   POT:       Proof of Transit
+
+3.  In-situ OAM Metadata Transport in IPv6
+
+   IOAM data is carried in IPv6 packets as Hop-by-Hop or Destination
+   options.  One IPv6 Destination Options and Hop-by-Hop Options Type
+   codepoint is assigned for IOAM.  Multiple options with the same
+   Option Type MAY appear in the same Hop-by-Hop Options or Destination
+   Options header, with varying content.  This mechanism of in-situ OAM
+   in IPv6 is used to enhance diagnostics of IPv6 networks.  It
+   complements other mechanisms proposed to enhance diagnostics of IPv6
+   networks, such as the IPv6 Performance and Diagnostic Metrics
+   Destination Option described in [RFC8250].
+
+   IPv6 Hop-by-Hop and Destination Option format for carrying in-situ
+   OAM data fields:
+
+
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |  Option Type  |  Opt Data Len |   Reserved    |   IOAM Type   |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+<-+
+   |                                                               |  |
+   .                                                               .  I
+   .                     Option Data                               .  O
+   .                                                               .  A
+   .                                                               .  M
+   .                                                               .  .
+   .                                                               .  O
+   .                                                               .  P
+   .                                                               .  T
+   .                                                               .  I
+   .                                                               .  O
+   .                                                               .  N
+   .                                                               .  |
+   |                                                               |  |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+<-+
+
+
+
+
+
+Bhandari, et al.        Expires December 31, 2018               [Page 3]
+
+Internet-Draft       In-situ OAM IPv6 encapsulation            June 2018
+
+
+   Option Type:  8-bit identifier of the type of option.
+
+   Opt Data Len:  8-bit unsigned integer.  Length of the Reserved and
+      Option Data field of this option, in octets.
+
+   Reserved:  8-bit field MUST be set to zero upon transmission and
+      ignored upon reception.
+
+   IOAM Type:  8-bit field as defined in section 7.2 in
+      [I-D.ietf-ippm-ioam-data].
+
+   Option Data:  Variable-length field.  Option-Type-specific data.
+
+   In-situ OAM Options are inserted as Option data as follows:
+
+   1.  Pre-allocated Tracing Option: The in-situ OAM Preallocated
+       Tracing option defined in [I-D.ietf-ippm-ioam-data] is
+       represented as a IPv6 option in hop by hop extension header:
+
+       Option Type:  001xxxxx 8-bit identifier of the IOAM type of
+          option. xxxxx=TBD.
+
+       IOAM Type:  IOAM Pre-allocated Trace Option Type.
+
+   2.  Incremental Tracing Option: The in-situ OAM Incremental Tracing
+       option defined in [I-D.ietf-ippm-ioam-data] is represented as a
+       IPv6 option in hop by hop extension header:
+
+       Option Type:  001xxxxx 8-bit identifier of the IOAM type of
+          option. xxxxx=TBD.
+
+       IOAM Type:  IOAM Incremental Trace Option Type.
+
+   3.  Proof of Transit Option: The in-situ OAM POT option defined in
+       [I-D.ietf-ippm-ioam-data] is represented as a IPv6 option in hop
+       by hop extension header:
+
+       Option Type:  001xxxxx 8-bit identifier of the IOAM type of
+          option. xxxxx=TBD.
+
+       IOAM Type:  IOAM POT Option Type.
+
+   4.  Edge to Edge Option: The in-situ OAM E2E option defined in
+       [I-D.ietf-ippm-ioam-data] is represented as a IPv6 option in IPv6
+       option in destination options extension header:
+
+       Option Type:  000xxxxx 8-bit identifier of the IOAM type of
+          option. xxxxx=TBD.
+
+
+
+Bhandari, et al.        Expires December 31, 2018               [Page 4]
+
+Internet-Draft       In-situ OAM IPv6 encapsulation            June 2018
+
+
+       IOAM Type:  IOAM E2E Option Type.
+
+   All the in-situ OAM IPv6 options defined here have alignment
+   requirements.  Specifically, they all require 4n alignment.  This
+   ensures that 4 octet fields specified in [I-D.ietf-ippm-ioam-data]
+   such as transit delay are aligned at a multiple-of-4 offset from the
+   start of the Hop-by-Hop Options header.  In addition, to maintain
+   IPv6 extension header 8-octet alignment and avoid the need to add or
+   remove padding at every hop, the Trace-Type for Incremental Tracing
+   Option in IPv6 MUST be selected such that the IOAM node data length
+   is a multiple of 8-octets.
+
+4.  Security Considerations
+
+   This document describes the encapsulation of IOAM data fields in
+   IPv6.  Security considerations of the specific IOAM data fields for
+   each case (i.e., Trace, Proof of Transit, and E2E) are described in
+   defined in [I-D.ietf-ippm-ioam-data].
+
+   As this document describes new options for IPv6 , these are similar
+   to the security considerations of [RFC8200] and the new weakness
+   documented in [RFC8250].
+
+5.  IANA Considerations
+
+   This draft requests the following IPv6 Option Type assignments from
+   the Destination Options and Hop-by-Hop Options sub-registry of
+   Internet Protocol Version 6 (IPv6) Parameters.
+
+   http://www.iana.org/assignments/ipv6-parameters/ipv6-
+   parameters.xhtml#ipv6-parameters-2
+
+      Hex Value    Binary Value      Description           Reference
+                   act chg rest
+      ----------------------------------------------------------------
+      TBD_1_0      00   0  TBD_1     IOAM                  [This draft]
+      TBD_1_1      00   1  TBD_1     IOAM                  [This draft]
+
+6.  Acknowledgements
+
+   The authors would like to thank Tom Herbert, Eric Vyncke, Nalini
+   Elkins, Srihari Raghavan, Ranganathan T S, Karthik Babu Harichandra
+   Babu, Akshaya Nadahalli, Stefano Previdi, Hemant Singh, Erik
+   Nordmark, LJ Wobker, and Andrew Yourtchenko for the comments and
+   advice.  For the IPv6 encapsulation, this document leverages concepts
+   described in [I-D.kitamura-ipv6-record-route].  The authors would
+   like to acknowledge the work done by the author Hiroshi Kitamura and
+   people involved in writing it.
+
+
+
+Bhandari, et al.        Expires December 31, 2018               [Page 5]
+
+Internet-Draft       In-situ OAM IPv6 encapsulation            June 2018
+
+
+7.  References
+
+7.1.  Normative References
+
+   [I-D.ietf-ippm-ioam-data]
+              Brockners, F., Bhandari, S., Pignataro, C., Gredler, H.,
+              Leddy, J., Youell, S., Mizrahi, T., Mozes, D., Lapukhov,
+              P., Chang, R., and d. daniel.bernier@bell.ca, "Data Fields
+              for In-situ OAM", draft-ietf-ippm-ioam-data-01 (work in
+              progress), October 2017.
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119,
+              DOI 10.17487/RFC2119, March 1997,
+              <https://www.rfc-editor.org/info/rfc2119>.
+
+   [RFC8174]  Leiba, B., "Ambiguity of Uppercase vs Lowercase in RFC
+              2119 Key Words", BCP 14, RFC 8174, DOI 10.17487/RFC8174,
+              May 2017, <https://www.rfc-editor.org/info/rfc8174>.
+
+7.2.  Informative References
+
+   [I-D.kitamura-ipv6-record-route]
+              Kitamura, H., "Record Route for IPv6 (PR6) Hop-by-Hop
+              Option Extension", draft-kitamura-ipv6-record-route-00
+              (work in progress), November 2000.
+
+   [RFC8200]  Deering, S. and R. Hinden, "Internet Protocol, Version 6
+              (IPv6) Specification", STD 86, RFC 8200,
+              DOI 10.17487/RFC8200, July 2017,
+              <https://www.rfc-editor.org/info/rfc8200>.
+
+   [RFC8250]  Elkins, N., Hamilton, R., and M. Ackermann, "IPv6
+              Performance and Diagnostic Metrics (PDM) Destination
+              Option", RFC 8250, DOI 10.17487/RFC8250, September 2017,
+              <https://www.rfc-editor.org/info/rfc8250>.
+
+Authors' Addresses
+
+   Shwetha Bhandari
+   Cisco Systems, Inc.
+   Cessna Business Park, Sarjapura Marathalli Outer Ring Road
+   Bangalore, KARNATAKA 560 087
+   India
+
+   Email: shwethab@cisco.com
+
+
+
+
+
+Bhandari, et al.        Expires December 31, 2018               [Page 6]
+
+Internet-Draft       In-situ OAM IPv6 encapsulation            June 2018
+
+
+   Frank Brockners
+   Cisco Systems, Inc.
+   Hansaallee 249, 3rd Floor
+   DUESSELDORF, NORDRHEIN-WESTFALEN  40549
+   Germany
+
+   Email: fbrockne@cisco.com
+
+
+   Carlos Pignataro
+   Cisco Systems, Inc.
+   7200-11 Kit Creek Road
+   Research Triangle Park, NC  27709
+   United States
+
+   Email: cpignata@cisco.com
+
+
+   Hannes Gredler
+   RtBrick Inc.
+
+   Email: hannes@rtbrick.com
+
+
+   John Leddy
+   Comcast
+
+   Email: John_Leddy@cable.comcast.com
+
+
+   Stephen Youell
+   JP Morgan Chase
+   25 Bank Street
+   London  E14 5JP
+   United Kingdom
+
+   Email: stephen.youell@jpmorgan.com
+
+
+   Tal Mizrahi
+   Marvell
+   6 Hamada St.
+   Yokneam  20692
+   Israel
+
+   Email: talmi@marvell.com
+
+
+
+
+
+Bhandari, et al.        Expires December 31, 2018               [Page 7]
+
+Internet-Draft       In-situ OAM IPv6 encapsulation            June 2018
+
+
+   Aviv Kfir
+   Mellanox Technologies, Inc.
+   350 Oakmead Parkway, Suite 100
+   Sunnyvale, CA  94085
+   U.S.A.
+
+   Email: avivk@mellanox.com
+
+
+   Barak Gafni
+   Mellanox Technologies, Inc.
+   350 Oakmead Parkway, Suite 100
+   Sunnyvale, CA  94085
+   U.S.A.
+
+   Email: gbarak@mellanox.com
+
+
+   Petr Lapukhov
+   Facebook
+   1 Hacker Way
+   Menlo Park, CA  94025
+   US
+
+   Email: petr@fb.com
+
+
+   Mickey Spiegel
+   Barefoot Networks
+   4750 Patrick Henry Drive
+   Santa Clara, CA  95054
+   US
+
+   Email: mspiegel@barefootnetworks.com
+
+
+   Suresh Krishnan
+   Kaloom
+
+   Email: suresh@kaloom.com
+
+
+
+
+
+
+
+
+
+
+
+Bhandari, et al.        Expires December 31, 2018               [Page 8]


### PR DESCRIPTION
Request only one IPv6 Options Type codepoint rather than 4. Note that there
are only 32 codepoints total, and 17 are already allocated.

Clarify the alignment constraint of 4n.