### PR TITLE
Updates to draft-ietf-ippm-ioam-data-07 per WG discussion

### DIFF
--- a/drafts/draft-ietf-ippm-ioam-data.xml
+++ b/drafts/draft-ietf-ippm-ioam-data.xml
@@ -21,7 +21,7 @@
 <!ENTITY RFC5905 SYSTEM "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.5905.xml">
 <!ENTITY RFC7384 SYSTEM "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.7384.xml">
 <!ENTITY RFC8300 SYSTEM "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.8300.xml">
-<!ENTITY I-D.brockners-proof-of-transit SYSTEM "http://xml2rfc.tools.ietf.org/public/rfc/bibxml-ids/reference.I-D.brockners-proof-of-transit.xml">
+<!ENTITY I-D.ietf-sfc-proof-of-transit SYSTEM "http://xml2rfc.tools.ietf.org/public/rfc/bibxml-ids/reference.I-D.ietf-sfc-proof-of-transit.xml">
 <!ENTITY I-D.ietf-spring-segment-routing SYSTEM "http://xml2rfc.tools.ietf.org/public/rfc/bibxml-ids/reference.I-D.ietf-spring-segment-routing.xml">
 <!ENTITY I-D.previdi-isis-segment-routing-extensions SYSTEM "http://xml2rfc.tools.ietf.org/public/rfc/bibxml-ids/reference.I-D.previdi-isis-segment-routing-extensions.xml">
 <!ENTITY I-D.ietf-ippm-6man-pdm-option SYSTEM "http://xml2rfc.tools.ietf.org/public/rfc/bibxml-ids/reference.I-D.ietf-ippm-6man-pdm-option.xml">
@@ -60,7 +60,7 @@
 <?rfc subcompact="no" ?>
 <!-- keep one blank line between list items -->
 <!-- end of list of popular I-D processing instructions -->
-<rfc category="std" docName="draft-ietf-ippm-ioam-data-06" ipr="trust200902">
+<rfc category="std" docName="draft-ietf-ippm-ioam-data-07" ipr="trust200902">
   <!-- ipr="full3978"-->
 
   <!-- category values: std, bcp, info, exp, and historic
@@ -153,11 +153,11 @@
     <author fullname="John Leddy" initials="J." surname="Leddy">
       <address>
         <postal>
-          <street></street>
+          <street/>
 
-          <city></city>
+          <city/>
 
-          <code></code>
+          <code/>
 
           <country>United States</country>
         </postal>
@@ -189,11 +189,11 @@
 
       <address>
         <postal>
-          <street></street>
+          <street/>
 
-          <city></city>
+          <city/>
 
-          <code></code>
+          <code/>
 
           <country>Israel</country>
         </postal>
@@ -203,17 +203,17 @@
     </author>
 
     <author fullname="David Mozes" initials="D." surname="Mozes">
-      <organization></organization>
+      <organization/>
 
       <address>
         <postal>
-          <street></street>
+          <street/>
 
-          <city></city>
+          <city/>
 
-          <code></code>
+          <code/>
 
-          <country></country>
+          <country/>
         </postal>
 
         <email>mosesster@gmail.com</email>
@@ -252,7 +252,7 @@
           <country>US</country>
         </postal>
 
-        <email></email>
+        <email/>
       </address>
     </author>
 
@@ -261,11 +261,11 @@
 
       <address>
         <postal>
-          <street></street>
+          <street/>
 
-          <city></city>
+          <city/>
 
-          <code></code>
+          <code/>
 
           <country>Canada</country>
         </postal>
@@ -294,7 +294,7 @@
       </address>
     </author>
 
-    <date day="04" month="July" year="2019" />
+    <date day="03" month="September" year="2019"/>
 
     <!-- If the month and year are both specified and are the current ones, xml2rfc will fill 
          in the current day for you. If only the current year is specified, xml2rfc will fill 
@@ -344,27 +344,26 @@
       is added to the data packets rather than is being sent within packets
       specifically dedicated to OAM. IOAM is to complement mechanisms such as
       Ping or Traceroute, or more recent active probing mechanisms as
-      described in <xref target="I-D.lapukhov-dataplane-probe"></xref>. In
-      terms of "active" or "passive" OAM, "in-situ" OAM can be considered a
-      hybrid OAM type. While no extra packets are sent, IOAM adds information
-      to the packets therefore cannot be considered passive. In terms of the
-      classification given in <xref target="RFC7799"></xref> IOAM could be
-      portrayed as Hybrid Type 1. "In-situ" mechanisms do not require extra
-      packets to be sent and hence don't change the packet traffic mix within
-      the network. IOAM mechanisms can be leveraged where mechanisms using
-      e.g. ICMP do not apply or do not offer the desired results, such as
-      proving that a certain traffic flow takes a pre-defined path, SLA
-      verification for the live data traffic, detailed statistics on traffic
-      distribution paths in networks that distribute traffic across multiple
-      paths, or scenarios in which probe traffic is potentially handled
-      differently from regular data traffic by the network devices.</t>
+      described in <xref target="I-D.lapukhov-dataplane-probe"/>. In terms of
+      "active" or "passive" OAM, "in-situ" OAM can be considered a hybrid OAM
+      type. "In-situ" mechanisms do not require extra packets to be sent. IOAM
+      adds information to the already available data packets and therefore
+      cannot be considered passive. In terms of the classification given in
+      <xref target="RFC7799"/> IOAM could be portrayed as Hybrid Type 1. IOAM
+      mechanisms can be leveraged where mechanisms using e.g. ICMP do not
+      apply or do not offer the desired results, such as proving that a
+      certain traffic flow takes a pre-defined path, SLA verification for the
+      live data traffic, detailed statistics on traffic distribution paths in
+      networks that distribute traffic across multiple paths, or scenarios in
+      which probe traffic is potentially handled differently from regular data
+      traffic by the network devices.</t>
     </section>
 
     <section anchor="Conventions" title="Conventions">
       <t>The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
       "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
       document are to be interpreted as described in <xref
-      target="RFC2119"></xref>.</t>
+      target="RFC2119"/>.</t>
 
       <t>Abbreviations used in this document:</t>
 
@@ -372,7 +371,7 @@
           <t hangText="E2E">Edge to Edge</t>
 
           <t hangText="Geneve:">Generic Network Virtualization Encapsulation
-          <xref target="I-D.ietf-nvo3-geneve"></xref></t>
+          <xref target="I-D.ietf-nvo3-geneve"/></t>
 
           <t hangText="IOAM:">In-situ Operations, Administration, and
           Maintenance</t>
@@ -380,7 +379,7 @@
           <t hangText="MTU:">Maximum Transmit Unit</t>
 
           <t hangText="NSH:">Network Service Header <xref
-          target="RFC8300"></xref></t>
+          target="RFC8300"/></t>
 
           <t hangText="OAM:">Operations, Administration, and Maintenance</t>
 
@@ -394,7 +393,7 @@
 
           <t hangText="VXLAN-GPE:">Virtual eXtensible Local Area Network,
           Generic Protocol Extension <xref
-          target="I-D.ietf-nvo3-vxlan-gpe"></xref></t>
+          target="I-D.ietf-nvo3-vxlan-gpe"/></t>
         </list></t>
     </section>
 
@@ -414,26 +413,27 @@
       a network domain can include an enterprise campus using physical
       connections between devices or an overlay network using virtual
       connections / tunnels for connectivity between said devices. A network
-      domain is defined by its perimeter or edge. Designers of carrier
-      protocols for IOAM must specify mechanisms to ensure that IOAM data
+      domain is defined by its perimeter or edge. Designers of protocol
+      encapsulations for IOAM must specify mechanisms to ensure that IOAM data
       stays within an IOAM domain. In addition, the operator of such a domain
       is expected to put provisions in place to ensure that IOAM data does not
       leak beyond the edge of an IOAM domain, e.g. using for example packet
-      filtering methods. The operator should consider potential operational
-      impact of IOAM to mechanisms such as ECMP processing (e.g.
+      filtering methods. The operator should consider the potential
+      operational impact of IOAM to mechanisms such as ECMP processing (e.g.
       load-balancing schemes based on packet length could be impacted by the
       increased packet size due to IOAM), path MTU (i.e. ensure that the MTU
       of all links within a domain is sufficiently large to support the
       increased packet size due to IOAM) and ICMP message handling (i.e. in
       case of a native IPv6 transport, IOAM support for ICMPv6 Echo
       Request/Reply could desired which would translate into ICMPv6 extensions
-      to enable IOAM data fields to be copied from an Echo Request message to
+      to enable IOAM-Data-Fields to be copied from an Echo Request message to
       an Echo Reply message).</t>
 
-      <t>IOAM control points: IOAM data fields are added to or removed from
+      <t>IOAM control points: IOAM-Data-Fields are added to or removed from
       the live user traffic by the devices which form the edge of a domain.
-      Devices within an IOAM domain can update and/or add IOAM data-fields.
-      Domain edge devices can be hosts or network devices.</t>
+      Devices which form an IOAM-Domain can add, update or remove
+      IOAM-Data-Fields. Edge devices of an IOAM-Domain can be hosts or network
+      devices.</t>
 
       <t>Traffic-sets that IOAM is applied to: IOAM can be deployed on all or
       only on subsets of the live user traffic. It SHOULD be possible to
@@ -443,104 +443,117 @@
 
       <t>Encapsulation independence: Data formats for IOAM SHOULD be defined
       in a transport-independent manner. IOAM applies to a variety of
-      encapsulating protocols. A definition of how IOAM data fields are
-      carried by different transport protocols is outside the scope of this
-      document.</t>
+      encapsulating protocols. A definition of how IOAM-Data-Fields are
+      encapsulated into "parent" protocols, like NSH or IPv6 is outside the
+      scope of this document.</t>
 
       <t>Layering: If several encapsulation protocols (e.g., in case of
-      tunneling) are stacked on top of each other, IOAM data-records could be
-      present at every layer. The behavior follows the ships-in-the-night
-      model, i.e. IOAM data in one layer is independent from IOAM data in
-      another layer. Layering allows operators to instrument the protocol
-      layer they want to measure. The different layers could, but do not have
-      to share the same IOAM encapsulation and decapsulation.</t>
+      tunneling) are stacked on top of each other, IOAM-Data-Fields could be
+      present at multiple layers. The behavior follows the ships-in-the-night
+      model, i.e. IOAM-Data-Fields in one layer are independent from
+      IOAM-Data-Fields in another layer. Layering allows operators to
+      instrument the protocol layer they want to measure. The different layers
+      could, but do not have to share the same IOAM encapsulation
+      mechanisms.</t>
 
-      <t>IOAM implementation: The IOAM data-field definitions take the
+      <t>IOAM implementation: The definition of the IOAM-Data-Fields take the
       specifics of devices with hardware data-plane and software data-plane
       into account.</t>
     </section>
 
-    <section anchor="IOAM_option_format" title="IOAM Data Types and Formats">
-      <t>This section defines IOAM data types and data fields and associated
-      data types required for IOAM.</t>
+    <section anchor="IOAM_option_format"
+             title="IOAM Data-Fields, Types, Nodes">
+      <t>This section details IOAM-related nomenclature and describes data
+      types such as IOAM-Data-Fields, IOAM-Types, IOAM-Namespaces as well as
+      the different types of IOAM nodes.</t>
 
-      <t>To accommodate the different uses of IOAM, IOAM data fields fall into
-      different categories, as specified below. In IOAM these categories are
-      referred to as IOAM-Types. A common registry is maintained for
-      IOAM-Types, see <xref target="IOAM-type-registry"></xref> for details.
-      Corresponding to these IOAM-Types, different IOAM data fields are
-      defined. IOAM data fields can be encapsulated into a variety of
-      protocols, such as NSH, Geneve, IPv6, etc. The definition of how IOAM
-      data fields are encapsulated into other protocols is outside the scope
-      of this document.</t>
+      <section title="IOAM Data-Fields and Option-Types">
+        <t>An IOAM-Data-Field is a set of bits with a defined format and
+        meaning, which can be stored at a certain place in a packet for the
+        purpose of IOAM.</t>
 
-      <t>This document defines four IOAM-Types, as specified in this
-      section:</t>
+        <t>To accommodate the different uses of IOAM, IOAM-Data-Fields fall
+        into different categories. In IOAM these categories are referred to as
+        IOAM-Option-Types. A common registry is maintained for
+        IOAM-Option-Types, see <xref target="IOAM-type-registry"/> for
+        details. Corresponding to these IOAM-Option-Types, different
+        IOAM-Data-Fields are defined. IOAM-Data-Fields can be encapsulated
+        into a variety of protocols, such as NSH, Geneve, IPv6, etc. The
+        definition of how IOAM-Data-Fields are encapsulated into other
+        protocols is outside the scope of this document. </t>
 
-      <t><list style="symbols">
-          <t>Pre-allocated Trace Option</t>
+        <t>This document defines four IOAM-Option-Types:<list style="symbols">
+            <t>Pre-allocated Trace Option-Type</t>
 
-          <t>Incremental Trace Option</t>
+            <t>Incremental Trace Option-Type</t>
 
-          <t>Proof of Transit (POT) Option</t>
+            <t>Proof of Transit (POT) Option-Type</t>
 
-          <t>Edge-to-Edge (E2E) Option</t>
-        </list></t>
+            <t>Edge-to-Edge (E2E) Option-Type</t>
+          </list></t>
+      </section>
 
-      <t>IOAM is expected to be deployed in a specific domain rather than on
-      the overall Internet. The part of the network which employs IOAM is
-      referred to as the "IOAM-domain". IOAM data is added to a packet upon
-      entering the IOAM-domain and is removed from the packet when exiting the
-      domain. Within the IOAM-domain, the IOAM data may be updated by network
-      nodes that the packet traverses. The device which adds an IOAM data
-      container to the packet to capture IOAM data is called the "IOAM
-      encapsulating node", whereas the device which removes the IOAM data
-      container is referred to as the "IOAM decapsulating node". Nodes within
-      the domain which are aware of IOAM data and read and/or write or process
-      the IOAM data are called "IOAM transit nodes". IOAM nodes which add or
-      remove the IOAM data fields can also update the IOAM data fields at the
-      same time. Or in other words, IOAM encapsulating or decapsulating nodes
-      can also serve as IOAM transit nodes at the same time. Note that not
-      every node in an IOAM domain needs to be an IOAM transit node. For
-      example, a deployment might require that packets traverse a set of
-      firewalls. In that case, only the set of firewall nodes would be IOAM
-      transit nodes rather than all nodes.</t>
+      <section title="IOAM-Domains and types of IOAM Nodes">
+        <t>IOAM is expected to be deployed in a specific domain. The part of
+        the network which employs IOAM is referred to as the "IOAM-Domain".
+        One or more IOAM-Option-Types are added to a packet upon entering the
+        IOAM-Domain and are removed from the packet when exiting the domain.
+        Within the IOAM-Domain, the IOAM-Data-Fields MAY be updated by network
+        nodes that the packet traverses. An IOAM-Domain consists of "IOAM
+        encapsulating nodes", "IOAM decapsulating nodes" and "IOAM transit
+        nodes". The role of a node (i.e. encapsulating, transit,
+        decapsulating) is defined within an IOAM-Namespace (see below). A node
+        can have different roles in different IOAM-Namespaces.</t>
 
-      <t>An IOAM encapsulating node incorporates one or more IOAM-Types (from
-      the list of four IOAM-Types above) into packets that IOAM is enabled
-      for. If IOAM is enabled for a selected subset of the traffic, the
-      encapsulating node is responsible for applying the IOAM functionality to
-      the selected subset.</t>
+        <t>A device which adds at least one IOAM-Option-Type to the packet is
+        called the "IOAM encapsulating node", whereas a device which removes
+        an IOAM-Option-Type is referred to as the "IOAM decapsulating node".
+        Nodes within the domain which are aware of IOAM data and read and/or
+        write or process the IOAM data are called "IOAM transit nodes". IOAM
+        nodes which add or remove the IOAM-Data-Fields can also update the
+        IOAM-Data-Fields at the same time. Or in other words, IOAM
+        encapsulating or decapsulating nodes can also serve as IOAM transit
+        nodes at the same time. Note that not every node in an IOAM domain
+        needs to be an IOAM transit node. For example, a deployment might
+        require that packets traverse a set of firewalls which support IOAM.
+        In that case, only the set of firewall nodes would be IOAM transit
+        nodes rather than all nodes.</t>
 
-      <t>An IOAM transit node updates one or more of the IOAM data fields. If
-      both the pre-allocated and the incremental trace options are present in
-      the packet, each IOAM transit node will update at most one of these
-      options. A transit node cannot add new IOAM options to a packet, and
-      cannot change an IOAM Edge-to-Edge Option.</t>
+        <t>An "IOAM encapsulating node" incorporates one or more
+        IOAM-Option-Types (from the list of IOAM-Types, see <xref
+        target="IOAM-type-registry"/>) into packets that IOAM is enabled for.
+        If IOAM is enabled for a selected subset of the traffic, the IOAM
+        encapsulating node is responsible for applying the IOAM functionality
+        to the selected subset.</t>
 
-      <t>An IOAM decapsulating node removes all the IOAM-Types from
-      packets.</t>
+        <t>An "IOAM transit node" updates one or more of the IOAM-Data-Fields.
+        If both the Pre-allocated and the Incremental Trace Option-Types are
+        present in the packet, each IOAM transit node will update at most one
+        of these Option-Types. A transit node MUST NOT add new
+        IOAM-Option-Types to a packet, and MUST NOT change the
+        IOAM-Data-Fields of an IOAM Edge-to-Edge Option-Type.</t>
 
-      <t>The role of a node (i.e. encapsulating, transit, decapsulating) is
-      defined within an IOAM namespace (see below). A node can have different
-      roles in different IOAM namespaces.</t>
+        <t>An "IOAM decapsulating node" removes IOAM-Option-Type(s) from
+        packets.</t>
+      </section>
 
-      <section anchor="ioam_namespaces" title="IOAM Namespaces">
-        <t>A subset or all of the IOAM option types and associated IOAM data
-        fields can be associated to an IOAM namespace. Namespaces add further
-        context to IOAM option types and associated IOAM data fields. Any IOAM
-        namespace MUST interpret the IOAM option types and associated IOAM
-        data fields per the definition in this document. Namespaces group
-        nodes to support different deployment approaches of IOAM (see a few
-        example use-cases below) as well as resolve issues which can occur due
-        to IOAM data fields not being globally unique (e.g. IOAM node
-        identifiers do not have to be globally unique). IOAM data fields are
-        defined within an IOAM namespace.</t>
+      <section anchor="ioam_namespaces" title="IOAM-Namespaces">
+        <t>A subset or all of the IOAM-Option-Types and their corresponding
+        IOAM-Data-Fields can be associated to an IOAM-Namespace.
+        IOAM-Namespaces add further context to IOAM-Option-Types and
+        associated IOAM-Data-Fields. Any IOAM-Namespace MUST interpret the
+        IOAM-Option-Types and associated IOAM-Data-Fields per the definition
+        in this document. IOAM-Namespaces group nodes to support different
+        deployment approaches of IOAM (see a few example use-cases below) as
+        well as resolve issues which can occur due to IOAM-Data-Fields not
+        being globally unique (e.g. IOAM node identifiers do not have to be
+        globally unique). IOAM-Data-Fields significance is always within a
+        particular IOAM-Namespace.</t>
 
-        <t>An IOAM namespace is identified by a 16-bit namespace identifier
-        (Namespace-ID). Namespace identifiers MUST be present and populated in
-        all IOAM option headers. The Namespace-ID value is divided into two
-        sub-ranges:</t>
+        <t>An IOAM-Namespace is identified by a 16-bit namespace identifier
+        (Namespace-ID). IOAM-Namespace identifiers MUST be present and
+        populated in all IOAM-Option-Types. The Namespace-ID value is divided
+        into two sub-ranges:</t>
 
         <t><list style="symbols">
             <t>An operator-assigned range from 0x0001 to 0x7FFF</t>
@@ -556,153 +569,165 @@
         determine:</t>
 
         <t><list style="symbols">
-            <t>whether IOAM option header(s) need to be processed by a device:
+            <t>whether IOAM-Option-Type(s) need to be processed by a device:
             If the Namespace-ID contained in a packet does not match any
             Namespace-ID the node is configured to operate on, then the node
-            MUST NOT change the contents of the IOAM data fields.</t>
+            MUST NOT change the contents of the IOAM-Data-Fields.</t>
 
-            <t>which IOAM option headers need to be processed/updated in case
-            there are multiple IOAM option headers present in the packet.
-            Multiple option headers can be present in a packet in case of
-            overlapping IOAM domains or in case of a layered IOAM
+            <t>which IOAM-Option-Type needs to be processed/updated in case
+            there are multiple IOAM-Option-Types present in the packet.
+            Multiple IOAM-Option-Types can be present in a packet in case of
+            overlapping IOAM-Domains or in case of a layered IOAM
             deployment.</t>
 
-            <t>whether IOAM option header(s) should be removed from the
-            packet, e.g. at a domain edge or domain boundary.</t>
+            <t>whether IOAM-Option-Type(s) should be removed from the packet,
+            e.g. at a domain edge or domain boundary.</t>
           </list></t>
 
-        <t>IOAM namespaces support several different uses:</t>
+        <t>IOAM-Namespaces support several different uses:</t>
 
         <t><list style="symbols">
-            <t>Namespaces can be used by an operator to distinguish different
-            operational domains. Devices at domain edges can filter on
-            Namespace-IDs to provide for proper IOAM domain isolation.</t>
+            <t>IOAM-Namespaces can be used by an operator to distinguish
+            different operational domains. Devices at domain edges can filter
+            on Namespace-IDs to provide for proper IOAM-Domain isolation.</t>
 
-            <t>Namespaces provide additional context for IOAM data fields and
-            thus ensure that IOAM data is unique and can be interpreted
-            properly by management stations or network controllers. While, for
-            example, the IOAM node identifier (Node-ID) does not need to be
-            unique in a deployment (e.g. an operator may wish to use different
-            Node-IDs for different IOAM layers, even within the same device;
-            or Node-IDs might not be unique for other organizational reasons,
+            <t>IOAM-Namespaces provide additional context for IOAM-Data-Fields
+            and thus ensure that IOAM-Data-Fields are unique and can be
+            interpreted properly by management stations or network
+            controllers. While, for example, the node identifier field
+            (node_id, see below) does not need to be unique in a deployment
+            (e.g. an operator may wish to use different node identifiers for
+            different IOAM layers, even within the same device; or node
+            identifiers might not be unique for other organizational reasons,
             such as after a merger of two formerly separated organizations),
-            the combination of Node-ID and Namespace-ID will always be unique.
-            Similarly, namespaces can be used to define how certain IOAM data
-            fields are interpreted: IOAM offers three different timestamp
-            format options. The Namespace-ID can be used to determine the
-            timestamp format. IOAM data fields (e.g. buffer occupancy) which
-            do not have a unit associated are to be interpreted within the
-            context of a namespace.</t>
+            the combination of node_id and Namespace-ID will always be unique.
+            Similarly, IOAM-Namespaces can be used to define how certain
+            IOAM-Data-Fields are interpreted: IOAM offers three different
+            timestamp format options. The Namespace-ID can be used to
+            determine the timestamp format. IOAM-Data-Fields (e.g. buffer
+            occupancy) which do not have a unit associated are to be
+            interpreted within the context of a IOAM-Namespace.</t>
 
-            <t>Namespaces can be used to identify different sets of devices
-            (e.g., different types of devices) in a deployment: If an operator
-            desires to insert different IOAM data based on the device, the
-            devices could be grouped into multiple namespaces. This could be
-            due to the fact that the IOAM feature set differs between
-            different sets of devices, or it could be for reasons of optimized
-            space usage in the packet header. This could also stem from
-            hardware or operational limitations on the size of the trace data
-            that can be added and processed, preventing collection of a full
-            trace for a flow.<list style="symbols">
-                <t>Assigning different Namespace-IDs to different sets of
+            <t>IOAM-Namespaces can be used to identify different sets of
+            devices (e.g., different types of devices) in a deployment: If an
+            operator desires to insert different IOAM-Data-Fields based on the
+            device, the devices could be grouped into multiple
+            IOAM-Namespaces. This could be due to the fact that the IOAM
+            feature set differs between different sets of devices, or it could
+            be for reasons of optimized space usage in the packet header. It
+            could also stem from hardware or operational limitations on the
+            size of the trace data that can be added and processed, preventing
+            collection of a full trace for a flow.<list style="symbols">
+                <t>Assigning different IOAM Namespace-IDs to different sets of
                 nodes or network partitions and using the Namespace-ID as a
                 selector at the IOAM encapsulating node, a full trace for a
                 flow could be collected and constructed via partial traces in
                 different packets of the same flow. Example: An operator could
-                choose to group the devices of a domain into two namespaces,
-                in a way that at average, only every second hop would be
-                recorded by any device. To retrieve a full view of the
-                deployment, the captured IOAM data fields of the two
-                namespaces need to be correlated.</t>
+                choose to group the devices of a domain into two
+                IOAM-Namespaces, in a way that at average, only every second
+                hop would be recorded by any device. To retrieve a full view
+                of the deployment, the captured IOAM-Data-Fields of the two
+                IOAM-Namespaces need to be correlated.</t>
 
-                <t>Assigning different Namespace-IDs to different sets of
-                nodes or network partitions and using a separate IOAM header
-                for each Namespace-ID, a full trace for a flow could be
-                collected and constructed via partial traces from each IOAM
-                header in each of the packets in the flow. Example: An
-                operator could choose to group the devices of a domain into
-                two namespaces, in a way that each namespace is represented by
-                one of two IOAM headers in the packet. Each node would record
-                data only for the IOAM namespace that it belongs to, ignoring
-                the other IOAM header with a namespace to which it doesn't
+                <t>Assigning different IOAM Namespace-IDs to different sets of
+                nodes or network partitions and using a separate instance of
+                an IOAM-Option-Type for each Namespace-ID, a full trace for a
+                flow could be collected and constructed via partial traces
+                from each IOAM-Option-Type in each of the packets in the flow.
+                Example: An operator could choose to group the devices of a
+                domain into two IOAM-Namespaces, in a way that each
+                IOAM-Namespace is represented by one of two IOAM-Option-Types
+                in the packet. Each node would record data only for the
+                IOAM-Namespace that it belongs to, ignoring the other
+                IOAM-Option-Type with a IOAM-Namespace to which it doesn't
                 belong. To retrieve a full view of the deployment, the
-                captured IOAM data fields of the two namespaces need to be
-                correlated.</t>
+                captured IOAM-Data-Fields of the two IOAM-Namespaces need to
+                be correlated.</t>
               </list></t>
           </list></t>
       </section>
 
-      <section anchor="IOAM_tracing_option" title="IOAM Tracing Options">
-        <t>"IOAM tracing data" is expected to be collected at every node that
-        a packet traverses to ensure visibility into the entire path a packet
-        takes within an IOAM domain, i.e., in a typical deployment all nodes
-        in an in-situ OAM-domain would participate in IOAM and thus be IOAM
-        transit nodes, IOAM encapsulating or IOAM decapsulating nodes. If not
-        all nodes within a domain are IOAM capable, IOAM tracing information
-        (i.e., node data) will only be collected on those nodes which are IOAM
-        capable. Nodes which are not IOAM capable will forward the packet
-        without any changes to the IOAM data fields. The maximum number of
-        hops and the minimum path MTU of the IOAM domain is assumed to be
-        known.</t>
+      <section anchor="IOAM_tracing_option" title="IOAM Trace Option-Types">
+        <t>"IOAM tracing data" is expected to be collected at every IOAM
+        transit node that a packet traverses to ensure visibility into the
+        entire path a packet takes within an IOAM-Domain. I.e., in a typical
+        deployment all nodes in an IOAM-Domain would participate in IOAM and
+        thus be IOAM transit nodes, IOAM encapsulating or IOAM decapsulating
+        nodes. If not all nodes within a domain are IOAM capable, IOAM tracing
+        information (i.e., node data, see below) will only be collected on
+        those nodes which are IOAM capable. Nodes which are not IOAM capable
+        will forward the packet without any changes to the IOAM-Data-Fields.
+        The maximum number of hops and the minimum path MTU of the IOAM domain
+        is assumed to be known.</t>
 
-        <t>To optimize hardware and software implementations tracing is
+        <t>To optimize hardware and software implementations IOAM tracing is
         defined as two separate options. Any deployment MAY choose to
-        configure and support one or both of the following options. An
-        implementation of the transport protocol that carries these in-situ
-        OAM data MAY choose to support only one of the options. In the event
-        that both options are utilized at the same time, the Incremental Trace
-        Option MUST be placed before the Pre-allocated Trace Option. Given
-        that the operator knows which equipment is deployed in a particular
-        IOAM, the operator will decide by means of configuration which type(s)
-        of trace options will be enabled for a particular domain.</t>
+        configure and support one or both of the following options.</t>
 
         <t><list style="hanging">
-            <t hangText="Pre-allocated Trace Option:">This trace option is
-            defined as a container of node data fields with pre-allocated
-            space for each node to populate its information. This option is
-            useful for software implementations where it is efficient to
+            <t hangText="Pre-allocated Trace-Option:">This trace option is
+            defined as a container of node data fields (see below) with
+            pre-allocated space for each node to populate its information.
+            This option is useful for implementations where it is efficient to
             allocate the space once and index into the array to populate the
-            data during transit. The IOAM encapsulating node allocates the
-            option header and sets the fields in the option header. The in
-            situ OAM encapsulating node allocates an array which is used to
-            store operational data retrieved from every node while the packet
+            data during transit (e.g., software forwarders often fall into
+            this class). The IOAM encapsulating node allocates space for
+            Pre-allocated Trace Option-Type in the packet and sets
+            corresponding fields in this IOAM-Option-Type. The IOAM
+            encapsulating node allocates an array which is used to store
+            operational data retrieved from every node while the packet
             traverses the domain. IOAM transit nodes update the content of the
             array, and possibly update the checksums of outer headers. A
-            pointer which is part of the IOAM trace data points to the next
+            pointer which is part of the IOAM trace data, points to the next
             empty slot in the array. An IOAM transit node that updates the
             content of the pre-allocated option also updates the value of the
             pointer, which specifies where the next IOAM transit node fills in
-            its data.</t>
+            its data.The "node data list" array (see below) in the packet is
+            populated iteratively as the packet traverses the network,
+            starting with the last entry of the array, i.e., "node data list
+            [n]" is the first entry to be populated, "node data list [n-1]" is
+            the second one, etc.</t>
 
-            <t hangText="Incremental Trace Option:">This trace option is
+            <t hangText="Incremental Trace-Option:">This trace option is
             defined as a container of node data fields where each node
             allocates and pushes its node data immediately following the
             option header. This type of trace recording is useful for some of
-            the hardware implementations as this eliminates the need for the
+            the hardware implementations as it eliminates the need for the
             transit network elements to read the full array in the option and
-            allows for arbitrarily long packets as the MTU allows. The in-situ
-            OAM encapsulating node allocates the option header. The in-situ
-            OAM encapsulating node based on operational state and
-            configuration sets the fields in the header that control what node
-            data fields should be collected, and how large the node data list
-            can grow. The in-situ OAM transit nodes push their node data to
-            the node data list, decrease the remaining length available to
-            subsequent nodes, and adjust the lengths and possibly checksums in
-            outer headers.</t>
+            allows for arbitrarily long packets as the MTU allows. The IOAM
+            encapsulating node allocates space for the Incremental Trace
+            Option-Type. Based on operational state and configuration, the
+            IOAM encapsulating node sets the fields in the Option-Type that
+            control what IOAM-Data-Fields should be collected and how large
+            the node data list can grow. IOAM transit nodes push their node
+            data to the node data list, decrease the remaining length
+            available to subsequent nodes and adjust the lengths and possibly
+            checksums in outer headers.</t>
           </list></t>
 
-        <t>Every node data entry is to hold information for a particular IOAM
-        transit node that is traversed by a packet. The in-situ OAM
-        decapsulating node removes the IOAM data and processes and/or exports
-        the metadata. IOAM data uses its own name-space for information such
-        as node identifier or interface identifier. This allows for a
-        domain-specific definition and interpretation. For example: In one
-        case an interface-id could point to a physical interface (e.g., to
-        understand which physical interface of an aggregated link is used when
-        receiving or transmitting a packet) whereas in another case it could
-        refer to a logical interface (e.g., in case of tunnels).</t>
+        <t>A particular implementation of IOAM MAY choose to support only one
+        of the two trace option types. In the event that both options are
+        utilized at the same time, the Incremental Trace-Option MUST be placed
+        before the Pre-allocated Trace-Option. Deployments which mix devices
+        which either the Incremental Trace-Option or the Pre-allocated
+        Trace-Option could result in both Option-Types being present in a
+        packet. Given that the operator knows which equipment is deployed in a
+        particular IOAM, the operator will decide by means of configuration
+        which type(s) of trace options will be used for a particular
+        domain.</t>
 
-        <t>The following IOAM data is defined for IOAM tracing:</t>
+        <t>Every node data entry holds information for a particular IOAM
+        transit node that is traversed by a packet. The IOAM decapsulating
+        node removes the IOAM-Option-Type(s) and processes and/or exports the
+        associated data. IOAM-Data-Fields are defined in the context of an
+        IOAM-Namespace. This allows for a namespace-specific definition and
+        interpretation. For example: In one case an interface-id could point
+        to a physical interface (e.g., to understand which physical interface
+        of an aggregated link is used when receiving or transmitting a packet)
+        whereas in another case it could refer to a logical interface (e.g.,
+        in case of tunnels).</t>
+
+        <t>IOAM tracing can collect the following types of information:</t>
 
         <t><list style="symbols">
             <t>Identification of the IOAM node. An IOAM node identifier can
@@ -715,34 +740,33 @@
             <t>Identification of the interface that a packet was sent out on,
             i.e. egress interface.</t>
 
-            <t>Time of day when the packet was processed by the node.
-            Different definitions of processing time are feasible and
-            expected, though it is important that all devices of an in-situ
-            OAM domain follow the same definition.</t>
+            <t>Time of day when the packet was processed by the node as well
+            as the transit delay. Different definitions of processing time are
+            feasible and expected, though it is important that all devices of
+            an in-situ OAM domain follow the same definition.</t>
 
             <t>Generic data: Format-free information where syntax and semantic
             of the information is defined by the operator in a specific
-            deployment. For a specific deployment, all IOAM nodes should
+            deployment. For a specific IOAM-Namespace, all IOAM nodes should
             interpret the generic data the same way. Examples for generic IOAM
             data include geo-location information (location of the node at the
             time the packet was processed), buffer queue fill level or cache
             fill level at the time the packet was processed, or even a battery
             charge level.</t>
 
-            <t>A mechanism to detect whether IOAM trace data was added at
-            every hop or whether certain hops in the domain weren't in-situ
-            OAM transit nodes.</t>
-          </list>The "node data list" array in the packet is populated
-        iteratively as the packet traverses the network, starting with the
-        last entry of the array, i.e., "node data list [n]" is the first entry
-        to be populated, "node data list [n-1]" is the second one, etc.</t>
+            <t>Information to detect whether IOAM trace data was added at
+            every hop or whether certain hops in the domain weren't IOAM
+            transit nodes.</t>
+          </list></t>
 
         <section anchor="TraceOptionDef"
-                 title="Pre-allocated and Incremental Trace Options">
-          <t>The in-situ OAM pre-allocated trace option and the in-situ OAM
-          incremental trace option have similar formats. Except where noted
-          below, the internal formats and fields of the two trace options are
-          identical.</t>
+                 title="Pre-allocated and Incremental Trace Option-Types">
+          <t>The IOAM Pre-allocated Trace-Option and the IOAM Incremental
+          Trace-Option have similar formats. Except where noted below, the
+          internal formats and fields of the two trace options are identical.
+          Both Trace-Options consist of a fixed size "trace option header" and
+          a variable data space to store gathered data, the "node data
+          list":</t>
 
           <t><figure>
               <artwork><![CDATA[ 
@@ -782,40 +806,41 @@ The trace option data MUST be 4-octet aligned:
 
 ]]></artwork>
             </figure> <list style="hanging">
-              <t hangText="Namespace-ID:">16-bit identifier of an IOAM
-              namespace. The Namespace-ID value of 0x0000 is defined as the
-              default value and MUST be known to all the nodes implementing
-              IOAM. For any other Namespace-ID value that does not match any
-              Namespace-ID the node is configured to operate on, the node MUST
-              NOT change the contents of the IOAM data fields.</t>
+              <t hangText="Namespace-ID:">16-bit identifier of an
+              IOAM-Namespace. The Namespace-ID value of 0x0000 is defined as
+              the default value and MUST be known to all the nodes
+              implementing IOAM. For any other Namespace-ID value that does
+              not match any Namespace-ID the node is configured to operate on,
+              the node MUST NOT change the contents of the
+              IOAM-Data-Fields.</t>
 
               <t hangText="NodeLen:">5-bit unsigned integer. This field
               specifies the length of data added by each node in multiples of
               4-octets, excluding the length of the "Opaque State Snapshot"
-              field. <vspace blankLines="1" /> If IOAM-Trace-Type bit 7 is not
+              field. <vspace blankLines="1"/>If IOAM-Trace-Type bit 22 is not
               set, then NodeLen specifies the actual length added by each
-              node. If IOAM-Trace-Type bit 7 is set, then the actual length
+              node. If IOAM-Trace-Type bit 22 is set, then the actual length
               added by a node would be (NodeLen + Opaque Data Length). <vspace
-              blankLines="1" /> For example, if 3 IOAM-Trace-Type bits are set
+              blankLines="1"/>For example, if 3 IOAM-Trace-Type bits are set
               and none of them are wide, then NodeLen would be 3. If 3
               IOAM-Trace-Type bits are set and 2 of them are wide, then
-              NodeLen would be 5. <vspace blankLines="1" /> An IOAM
-              encapsulating node must set NodeLen. <vspace blankLines="1" /> A
-              node receiving an IOAM Pre-allocated or Incremental Trace Option
+              NodeLen would be 5. <vspace blankLines="1"/>An IOAM
+              encapsulating node must set NodeLen. <vspace blankLines="1"/>A
+              node receiving an IOAM Pre-allocated or Incremental Trace-Option
               may rely on the NodeLen value, or it may ignore the NodeLen
               value and calculate the node length from the IOAM-Trace-Type
-              bits.</t>
+              bits (see below).</t>
 
               <t anchor="TraceFlags" hangText="Flags">4-bit field. Flags are
               allocated by IANA, as specified in <xref
-              target="Flags-Registry-Sec"></xref>. The current document
-              allocates a single flag as follows: <list style="hanging">
+              target="Flags-Registry-Sec"/>. This document allocates a single
+              flag as follows: <list style="hanging">
                   <t hangText="Bit 0">"Overflow" (O-bit) (most significant
                   bit). This bit is set by the network element if there are
                   not enough octets left to record node data, no field is
                   added and the overflow "O-bit" must be set to "1" in the
-                  header. This is useful for transit nodes to ignore further
-                  processing of the option.</t>
+                  IOAM-Trace-Option header. This is useful for transit nodes
+                  to ignore further processing of the option.</t>
                 </list></t>
 
               <t hangText="RemainingLen:">7-bit unsigned integer. This field
@@ -830,20 +855,22 @@ The trace option data MUST be 4-octet aligned:
               the length of the "Opaque State Snapshot" if applicable, to
               determine whether or not data can be added by this node. When
               node data is added, the node MUST decrease RemainingLen by the
-              amount of data added. In the pre-allocated trace option, this is
-              used as an offset in data space to record the node data
-              element.</t>
+              amount of data added. In the pre-allocated trace option,
+              RemainingLength is used to derive the offset in data space to
+              record the node data element. Specifically, the recording of the
+              node data element would start from RemainingLen - NodeLen -
+              sizeof(opaque snapshot) in 4 octet units.</t>
 
               <t anchor="IOAMTraceType" hangText="IOAM-Trace-Type:">A 24-bit
               identifier which specifies which data types are used in this
               node data list.</t>
 
               <t hangText=" ">The IOAM-Trace-Type value is a bit field. The
-              following bit fields are defined in this document, with details
-              on each field described in the <xref
-              target="trace-node-data-element"></xref>. The order of packing
-              the data fields in each node data element follows the bit order
-              of the IOAM-Trace-Type field, as follows:<list hangIndent="9"
+              following bits are defined in this document, with details on
+              each bit described in the <xref
+              target="trace-node-data-element"/>. The order of packing the
+              data fields in each node data element follows the bit order of
+              the IOAM-Trace-Type field, as follows:<list hangIndent="9"
                   style="hanging">
                   <t hangText="Bit 0">(Most significant bit) When set
                   indicates presence of Hop_Lim and node_id in the node
@@ -862,14 +889,15 @@ The trace option data MUST be 4-octet aligned:
                   <t hangText="Bit 4">When set indicates presence of transit
                   delay in the node data.</t>
 
-                  <t hangText="Bit 5">When set indicates presence of namespace
-                  specific data (short format) in the node data.</t>
+                  <t hangText="Bit 5">When set indicates presence of
+                  IOAM-Namespace specific data (short format) in the node
+                  data.</t>
 
                   <t hangText="Bit 6">When set indicates presence of queue
                   depth in the node data.</t>
 
-                  <t hangText="Bit 7">When set indicates presence of variable
-                  length Opaque State Snapshot field.</t>
+                  <t hangText="Bit 7">When set indicates presence of the
+                  Checksum Complement node data.</t>
 
                   <t hangText="Bit 8">When set indicates presence of Hop_Lim
                   and node_id in wide format in the node data.</t>
@@ -879,12 +907,13 @@ The trace option data MUST be 4-octet aligned:
                   data.</t>
 
                   <t hangText="Bit 10">When set indicates presence of
-                  namespace specific data in wide format in the node data.</t>
+                  IOAM-Namespace specific data in wide format in the node
+                  data.</t>
 
                   <t hangText="Bit 11">When set indicates presence of buffer
                   occupancy in the node data.</t>
 
-                  <t hangText="Bit 12-22">Undefined. An IOAM encapsulating
+                  <t hangText="Bit 12-21">Undefined. An IOAM encapsulating
                   node MUST set the value of each of these bits to 0. If an
                   IOAM transit node receives a packet with one or more of
                   these bits set to 1, it must either: <list style="numbers">
@@ -898,15 +927,17 @@ The trace option data MUST be 4-octet aligned:
                       the IOAM-Trace-Type bits defined above.</t>
                     </list></t>
 
-                  <t hangText="Bit 23">When set indicates presence of the
-                  Checksum Complement node data.</t>
+                  <t hangText="Bit 22">When set indicates presence of variable
+                  length Opaque State Snapshot field.</t>
+
+                  <t hangText="Bit 23">Reserved: Must be set to zero upon
+                  transmission and ignored upon receipt.</t>
                 </list></t>
 
-              <t hangText=" "><xref target="trace-node-data-element"></xref>
-              describes the IOAM data types and their formats. Within an
-              in-situ OAM domain possible combinations of these bits making
-              the IOAM-Trace-Type can be restricted by configuration
-              knobs.</t>
+              <t hangText=" "><xref target="trace-node-data-element"/>
+              describes the IOAM-Data-Types and their formats. Within an
+              IOAM-Domain possible combinations of these bits making the
+              IOAM-Trace-Type can be restricted by configuration knobs.</t>
 
               <t hangText="Reserved:">8-bits. Must be zero.</t>
 
@@ -928,15 +959,25 @@ The trace option data MUST be 4-octet aligned:
 
         <section anchor="trace-node-data-element"
                  title="IOAM node data fields and associated formats">
-          <t>All the data fields MUST be 4-octet aligned. If a node which is
-          supposed to update an IOAM data field is not capable of populating
-          the value of a field set in the IOAM-Trace-Type, the field value
-          MUST be set to 0xFFFFFFFF for 4-octet fields or 0xFFFFFFFFFFFFFFFF
-          for 8-octet fields, indicating that the value is not populated,
-          except when explicitly specified in the field description below.</t>
+          <t>All the IOAM-Data-Fields MUST be 4-octet aligned. If a node which
+          is supposed to update an IOAM-Data-Field is not capable of
+          populating the value of a field set in the IOAM-Trace-Type, the
+          field value MUST be set to 0xFFFFFFFF for 4-octet fields or
+          0xFFFFFFFFFFFFFFFF for 8-octet fields, indicating that the value is
+          not populated, except when explicitly specified in the field
+          description below.</t>
 
-          <t>Data field and associated data type for each of the data field is
-          shown below:</t>
+          <t>Some IOAM-Data-Fields defined below, such as interface
+          identifiers or IOAM-Namespace specific data, are defined in both
+          "short format" as well as "wide format". Their use is not exclusive.
+          A deployment could choose to leverage both. For example,
+          ingress_if_id_(short format) could be an identifier for the physical
+          interface, whereas ingress_if_id_(wide format) could be an
+          identifier for a logical sub-interface of that physical
+          interface.</t>
+
+          <t>Data field and associated data type for each of the
+          IOAM-Data-Fields is shown below:</t>
 
           <t><list style="hanging">
               <t hangText="Hop_Lim and node_id:">4-octet field defined as
@@ -958,9 +999,10 @@ The trace option data MUST be 4-octet aligned:
                   are outside the scope of this memo.</t>
 
                   <t hangText="node_id:">3-octet unsigned integer. Node
-                  identifier field to uniquely identify a node within in-situ
-                  OAM domain. The procedure to allocate, manage and map the
-                  node_ids is beyond the scope of this document.</t>
+                  identifier field to uniquely identify a node within the
+                  IOAM-Namespace and associated IOAM-Domain. The procedure to
+                  allocate, manage and map the node_ids is beyond the scope of
+                  this document.</t>
                 </list></t>
 
               <t hangText="ingress_if_id and egress_if_id:">4-octet field
@@ -978,43 +1020,43 @@ The trace option data MUST be 4-octet aligned:
                   Interface identifier to record the egress interface the
                   packet is forwarded out of.</t>
                 </list>Note that due to the fact that IOAM uses its own
-              namespaces for IOAM data fields, data fields like interface
+              IOAM-Namespaces for IOAM-Data-Fields, data fields like interface
               identifiers can be used in a flexible way to represent system
               resources that are associated with ingressing or egressing
-              packets, i.e. an IOAM interface ID could represent a physical
+              packets, i.e. ingress_if_id could represent a physical
               interface, a virtual or logical interface, or even a queue.</t>
 
               <t hangText="timestamp seconds:">4-octet unsigned integer.
               Absolute timestamp in seconds that specifies the time at which
               the packet was received by the node. This field has three
               possible formats; based on either PTP <xref
-              target="IEEE1588v2"></xref>, NTP <xref target="RFC5905"></xref>,
-              or POSIX <xref target="POSIX"></xref>. The three timestamp
-              formats are specified in <xref target="TimestampSec"></xref>. In
-              all three cases, the Timestamp Seconds field contains the 32
-              most significant bits of the timestamp format that is specified
-              in <xref target="TimestampSec"></xref>. If a node is not capable
-              of populating this field, it assigns the value 0xFFFFFFFF. Note
-              that this is a legitimate value that is valid for 1 second in
-              approximately 136 years; the analyzer should correlate several
-              packets or compare the timestamp value to its own time-of-day in
-              order to detect the error indication.</t>
+              target="IEEE1588v2"/>, NTP <xref target="RFC5905"/>, or POSIX
+              <xref target="POSIX"/>. The three timestamp formats are
+              specified in <xref target="TimestampSec"/>. In all three cases,
+              the Timestamp Seconds field contains the 32 most significant
+              bits of the timestamp format that is specified in <xref
+              target="TimestampSec"/>. If a node is not capable of populating
+              this field, it assigns the value 0xFFFFFFFF. Note that this is a
+              legitimate value that is valid for 1 second in approximately 136
+              years; the analyzer should correlate several packets or compare
+              the timestamp value to its own time-of-day in order to detect
+              the error indication.</t>
 
               <t hangText="timestamp subseconds:">4-octet unsigned integer.
               Absolute timestamp in subseconds that specifies the time at
               which the packet was received by the node. This field has three
               possible formats; based on either PTP <xref
-              target="IEEE1588v2"></xref>, NTP <xref target="RFC5905"></xref>,
-              or POSIX <xref target="POSIX"></xref>. The three timestamp
-              formats are specified in <xref target="TimestampSec"></xref>. In
-              all three cases, the Timestamp Subseconds field contains the 32
-              least significant bits of the timestamp format that is specified
-              in <xref target="TimestampSec"></xref>. If a node is not capable
-              of populating this field, it assigns the value 0xFFFFFFFF. Note
-              that this is a legitimate value in the NTP format, valid for
-              approximately 233 picoseconds in every second. If the NTP format
-              is used the analyzer should correlate several packets in order
-              to detect the error indication.</t>
+              target="IEEE1588v2"/>, NTP <xref target="RFC5905"/>, or POSIX
+              <xref target="POSIX"/>. The three timestamp formats are
+              specified in <xref target="TimestampSec"/>. In all three cases,
+              the Timestamp Subseconds field contains the 32 least significant
+              bits of the timestamp format that is specified in <xref
+              target="TimestampSec"/>. If a node is not capable of populating
+              this field, it assigns the value 0xFFFFFFFF. Note that this is a
+              legitimate value in the NTP format, valid for approximately 233
+              picoseconds in every second. If the NTP format is used the
+              analyzer should correlate several packets in order to detect the
+              error indication.</t>
 
               <t hangText="transit delay:">4-octet unsigned integer in the
               range 0 to 2^31-1. It is the time in nanoseconds the packet
@@ -1032,9 +1074,9 @@ The trace option data MUST be 4-octet aligned:
                 </figure></t>
 
               <t hangText="namespace specific data:">4-octet field which can
-              be used by the node to add namespace specific data. This
+              be used by the node to add IOAM-Namespace specific data. This
               represents a "free-format" 4-octet bit field with its semantics
-              defined in the context of a specific namespace.<figure>
+              defined in the context of a specific IOAM-Namespace.<figure>
                   <artwork><![CDATA[ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                    namespace specific data                    |
@@ -1053,15 +1095,116 @@ The trace option data MUST be 4-octet aligned:
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+]]></artwork>
                 </figure></t>
 
-              <t hangText="Opaque State Snapshot:">Variable length field. It
-              allows the network element to store an arbitrary state in the
-              node data field, without a pre-defined schema. The schema is to
-              be defined within the context of a namespace. The schema needs
-              to be made known to the analyzer by some out-of-band mechanism.
-              The specification of this mechanism is beyond the scope of this
-              document. A 24-bit "Schema Id" field, interpreted within the
-              context of a namespace, indicates which particular schema is
-              used, and should be configured on the network element by the
+              <t hangText="Hop_Lim and node_id wide:">8-octet field defined as
+              follows: <figure>
+                  <artwork><![CDATA[ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|   Hop_Lim     |              node_id                          ~
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+~                         node_id (contd)                       |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+]]></artwork>
+                </figure><list style="hanging">
+                  <t hangText="Hop_Lim:">1-octet unsigned integer. It is set
+                  to the Hop Limit value in the packet at the node that
+                  records this data. Hop Limit information is used to identify
+                  the location of the node in the communication path. This is
+                  copied from the lower layer for e.g. TTL value in IPv4
+                  header or hop limit field from IPv6 header of the packet.
+                  The semantics of the Hop_Lim field depend on the lower layer
+                  protocol that IOAM is encapsulated over, and therefore its
+                  specific semantics are outside the scope of this memo.</t>
+
+                  <t hangText="node_id:">7-octet unsigned integer. Node
+                  identifier field to uniquely identify a node within the
+                  IOAM-Namespace and associated IOAM-Domain. The procedure to
+                  allocate, manage and map the node_ids is beyond the scope of
+                  this document.</t>
+                </list></t>
+
+              <t hangText="ingress_if_id and egress_if_id wide:">8-octet field
+              defined as follows: <figure>
+                  <artwork><![CDATA[ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                       ingress_if_id                           |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                       egress_if_id                            |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+]]></artwork>
+                </figure><list style="hanging">
+                  <t hangText="ingress_if_id:">4-octet unsigned integer.
+                  Interface identifier to record the ingress interface the
+                  packet was received on.</t>
+
+                  <t hangText="egress_if_id:">4-octet unsigned integer.
+                  Interface identifier to record the egress interface the
+                  packet is forwarded out of.</t>
+                </list></t>
+
+              <t hangText="namespace specific data wide:">8-octet field which
+              can be used by the node to add IOAM-Namespace specific data.
+              This represents a "free-format" 8-octet bit field with its
+              semantics defined in the context of a specific
+              IOAM-Namespace.<figure>
+                  <artwork><![CDATA[ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                    namespace specific data                    ~
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+~                namespace specific data (contd)                |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+]]></artwork>
+                </figure></t>
+
+              <t hangText="buffer occupancy:">4-octet unsigned integer field.
+              This field indicates the current status of the occupancy of the
+              common buffer pool used by a set of queues. The units of this
+              field depend on the equipment type and deployment and has to be
+              interpreted within the context of an IOAM-Namespace and/or
+              node-id if used. <figure>
+                  <artwork><![CDATA[ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                       buffer occupancy                        |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+]]></artwork>
+                </figure></t>
+
+              <t hangText="Checksum Complement:">4-octet node data which
+              contains a 4-octet Checksum Complement field. The Checksum
+              Complement is useful when IOAM is transported over
+              encapsulations that make use of a UDP transport, such as
+              VXLAN-GPE or Geneve. Without the Checksum Complement, nodes
+              adding IOAM node data must update the UDP Checksum field. When
+              the Checksum Complement is present, an IOAM encapsulating node
+              or IOAM transit node adding node data MUST carry out one of the
+              following two alternatives in order to maintain the correctness
+              of the UDP Checksum value: <list style="numbers">
+                  <t>Recompute the UDP Checksum field.</t>
+
+                  <t>Use the Checksum Complement to make a checksum-neutral
+                  update in the UDP payload; the Checksum Complement is
+                  assigned a value that complements the rest of the node data
+                  fields that were added by the current node, causing the
+                  existing UDP Checksum field to remain correct.</t>
+                </list> IOAM decapsulating nodes MUST recompute the UDP
+              Checksum field, since they do not know whether previous hops
+              modified the UDP Checksum field or the Checksum Complement
+              field. <vspace blankLines="1"/> Checksum Complement fields are
+              used in a similar manner in <xref target="RFC7820"/> and <xref
+              target="RFC7821"/>. <figure>
+                  <artwork><![CDATA[ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                   Checksum Complement                         |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+]]></artwork>
+                </figure></t>
+
+              <t hangText="Opaque State Snapshot:">Opaque State Snapshot is a
+              variable length field and immediately follows the fixed length
+              IOAM-Data-Fields defined above. It allows the network element to
+              store an arbitrary state in the node data field, without a
+              pre-defined schema. The schema is to be defined within the
+              context of an IOAM-Namespace. The schema needs to be made known
+              to the analyzer by some out-of-band mechanism. The specification
+              of this mechanism is beyond the scope of this document. A 24-bit
+              "Schema Id" field, interpreted within the context of an
+              IOAM-Namespace, indicates which particular schema is used, and
+              should be configured on the network element by the
               operator.<figure>
                   <artwork><![CDATA[    0                   1                   2                   3
     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
@@ -1086,108 +1229,10 @@ The trace option data MUST be 4-octet aligned:
                   <t hangText="Opaque data:">Variable length field. This field
                   is interpreted as specified by the schema identified by the
                   Schema ID.</t>
-                </list> When this field is part of the data field but a node
+                </list>When this field is part of the data field but a node
               populating the field has no opaque state data to report, the
               Length must be set to 0 and the Schema ID must be set to
               0xFFFFFF to mean no schema.</t>
-
-              <t hangText="Hop_Lim and node_id wide:">8-octet field defined as
-              follows: <figure>
-                  <artwork><![CDATA[ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|   Hop_Lim     |              node_id                          ~
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-~                         node_id (contd)                       |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+]]></artwork>
-                </figure><list style="hanging">
-                  <t hangText="Hop_Lim:">1-octet unsigned integer. It is set
-                  to the Hop Limit value in the packet at the node that
-                  records this data. Hop Limit information is used to identify
-                  the location of the node in the communication path. This is
-                  copied from the lower layer for e.g. TTL value in IPv4
-                  header or hop limit field from IPv6 header of the packet.
-                  The semantics of the Hop_Lim field depend on the lower layer
-                  protocol that IOAM is encapsulated over, and therefore its
-                  specific semantics are outside the scope of this memo.</t>
-
-                  <t hangText="node_id:">7-octet unsigned integer. Node
-                  identifier field to uniquely identify a node within in-situ
-                  OAM domain. The procedure to allocate, manage and map the
-                  node_ids is beyond the scope of this document.</t>
-                </list></t>
-
-              <t hangText="ingress_if_id and egress_if_id wide:">8-octet field
-              defined as follows: <figure>
-                  <artwork><![CDATA[ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                       ingress_if_id                           |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                       egress_if_id                            |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+]]></artwork>
-                </figure><list style="hanging">
-                  <t hangText="ingress_if_id:">4-octet unsigned integer.
-                  Interface identifier to record the ingress interface the
-                  packet was received on.</t>
-
-                  <t hangText="egress_if_id:">4-octet unsigned integer.
-                  Interface identifier to record the egress interface the
-                  packet is forwarded out of.</t>
-                </list></t>
-
-              <t hangText="namespace specific data wide:">8-octet field which
-              can be used by the node to add namespace specific data. This
-              represents a "free-format" 8-octet bit field with its semantics
-              defined in the context of a specific namespace.<figure>
-                  <artwork><![CDATA[ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                    namespace specific data                    ~
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-~                namespace specific data (contd)                |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-]]></artwork>
-                </figure></t>
-
-              <t hangText="buffer occupancy:">4-octet unsigned integer field.
-              This field indicates the current status of the occupancy of the
-              common buffer pool used by a set of queues. The units of this
-              field depend on the equipment type and deployment and has to be
-              interpreted within the context of a namespace and/or node-id if
-              used. <figure>
-                  <artwork><![CDATA[ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                       buffer occupancy                        |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+]]></artwork>
-                </figure></t>
-
-              <t hangText="Checksum Complement:">4-octet node data which
-              contains a two-octet Checksum Complement field, and a 2-octet
-              reserved field. The Checksum Complement is useful when IOAM is
-              transported over encapsulations that make use of a UDP
-              transport, such as VXLAN-GPE or Geneve. Without the Checksum
-              Complement, nodes adding IOAM node data must update the UDP
-              Checksum field. When the Checksum Complement is present, an IOAM
-              encapsulating node or IOAM transit node adding node data MUST
-              carry out one of the following two alternatives in order to
-              maintain the correctness of the UDP Checksum value: <list
-                  style="numbers">
-                  <t>Recompute the UDP Checksum field.</t>
-
-                  <t>Use the Checksum Complement to make a checksum-neutral
-                  update in the UDP payload; the Checksum Complement is
-                  assigned a value that complements the rest of the node data
-                  fields that were added by the current node, causing the
-                  existing UDP Checksum field to remain correct.</t>
-                </list> IOAM decapsulating nodes MUST recompute the UDP
-              Checksum field, since they do not know whether previous hops
-              modified the UDP Checksum field or the Checksum Complement
-              field. <vspace blankLines="1" /> Checksum Complement fields are
-              used in a similar manner in <xref target="RFC7820"></xref> and
-              <xref target="RFC7821"></xref>. <figure>
-                  <artwork><![CDATA[ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|      Checksum Complement      |           Reserved            |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+]]></artwork>
-                </figure></t>
             </list></t>
         </section>
 
@@ -1197,12 +1242,13 @@ The trace option data MUST be 4-octet aligned:
           formats, following the needs of the deployment. Some deployments
           might only be interested in recording the node identifiers, whereas
           others might be interested in recording node identifier and
-          timestamp. The section defines different types that an entry in
-          "node data list" can take.</t>
+          timestamp. The section provides example entries of the "node data
+          list".</t>
 
           <t><list style="hanging">
-              <t hangText="0xD40000:">IOAM-Trace-Type is 0xD40000 then the
-              format of node data is:<figure>
+              <t hangText="0xD40000:">IOAM-Trace-Type is 0xD40000
+              (0b110101000000000000000000) then the format of node data
+              is:<figure>
                   <artwork><![CDATA[     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
     |   Hop_Lim     |              node_id                          |
@@ -1218,8 +1264,8 @@ The trace option data MUST be 4-octet aligned:
 ]]></artwork>
                 </figure></t>
 
-              <t hangText="0xC00000:">IOAM-Trace-Type is 0xC00000 then the
-              format is:<figure>
+              <t hangText="0xC00000:">IOAM-Trace-Type is 0xC00000
+              (0b110000000000000000000000) then the format is:<figure>
                   <artwork><![CDATA[     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
     |   Hop_Lim     |              node_id                          |
@@ -1230,8 +1276,8 @@ The trace option data MUST be 4-octet aligned:
 ]]></artwork>
                 </figure></t>
 
-              <t hangText="0x900000:">IOAM-Trace-Type is 0x900000 then the
-              format is: <figure>
+              <t hangText="0x900000:">IOAM-Trace-Type is 0x900000
+              (0b100100000000000000000000) then the format is: <figure>
                   <artwork><![CDATA[     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
     |   Hop_Lim     |              node_id                          |
@@ -1242,8 +1288,8 @@ The trace option data MUST be 4-octet aligned:
 ]]></artwork>
                 </figure></t>
 
-              <t hangText="0x840000:">IOAM-Trace-Type is 0x840000 then the
-              format is:<figure>
+              <t hangText="0x840000:">IOAM-Trace-Type is 0x840000
+              (0b100001000000000000000000) then the format is:<figure>
                   <artwork><![CDATA[     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
     |   Hop_Lim     |              node_id                          |
@@ -1254,8 +1300,8 @@ The trace option data MUST be 4-octet aligned:
 ]]></artwork>
                 </figure></t>
 
-              <t hangText="0x940000:">IOAM-Trace-Type is 0x940000 then the
-              format is:<figure>
+              <t hangText="0x940000:">IOAM-Trace-Type is 0x940000
+              (0b100101000000000000000000) then the format is:<figure>
                   <artwork><![CDATA[     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
     |   Hop_Lim     |              node_id                          |
@@ -1268,13 +1314,17 @@ The trace option data MUST be 4-octet aligned:
 ]]></artwork>
                 </figure></t>
 
-              <t hangText="0x318000:">IOAM-Trace-Type is 0x318000 then the
-              format is:<figure>
+              <t hangText="0x308002:">IOAM-Trace-Type is 0x308002
+              (0b001100001000000000000010) then the format is:<figure>
                   <artwork><![CDATA[     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
     |                      timestamp seconds                        |
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
     |                    timestamp subseconds                       |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |   Hop_Lim     |              node_id                          |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |                         node_id(contd)                        |
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
     |   Length      |                     Schema Id                 |
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -1285,10 +1335,6 @@ The trace option data MUST be 4-octet aligned:
     .                                                               .
     .                                                               .
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    |   Hop_Lim     |              node_id                          |
-    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    |                         node_id(contd)                        |
-    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 
 ]]></artwork>
                 </figure></t>
@@ -1297,9 +1343,9 @@ The trace option data MUST be 4-octet aligned:
       </section>
 
       <section anchor="IOAM_proof_of_transit_option"
-               title="IOAM Proof of Transit Option">
-        <t>IOAM Proof of Transit data is to support the path or service
-        function chain <xref target="RFC7665"></xref> verification use cases.
+               title="IOAM Proof of Transit Option-Type">
+        <t>IOAM Proof of Transit Option-Type is to support path or service
+        function chain <xref target="RFC7665"/> verification use cases.
         Proof-of-transit uses methods like nested hashing or nested encryption
         of the IOAM data or mechanisms such as Shamir's Secret Sharing Schema
         (SSSS). While details on how the IOAM data for the proof of transit
@@ -1307,8 +1353,8 @@ The trace option data MUST be 4-octet aligned:
         nodes are outside the scope of the document, all of these approaches
         share the need to uniquely identify a packet as well as iteratively
         operate on a set of information that is handed from node to node.
-        Correspondingly, two pieces of information are added as IOAM data to
-        the packet:</t>
+        Correspondingly, two pieces of information are added as
+        IOAM-Data-Fields to the packet:</t>
 
         <t><list style="symbols">
             <t>Random: Unique identifier for the packet (e.g., 64-bits allow
@@ -1316,7 +1362,9 @@ The trace option data MUST be 4-octet aligned:
 
             <t>Cumulative: Information which is handed from node to node and
             updated by every node according to a verification algorithm.</t>
-          </list></t>
+          </list>The IOAM Proof of Transit Option-Type consist of a fixed size
+        "IOAM proof of transit option header" and "IOAM proof of transit
+        option data fields":</t>
 
         <t><figure>
             <artwork><![CDATA[ 
@@ -1328,7 +1376,8 @@ IOAM proof of transit option header:
 |       Namespace-ID            |IOAM POT Type  | IOAM POT flags| 
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 
-IOAM proof of transit option data MUST be 4-octet aligned.:
+IOAM proof of transit Option-Type IOAM-Data-Fields MUST be 
+4-octet aligned:
     
  0                   1                   2                   3
  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
@@ -1339,12 +1388,12 @@ IOAM proof of transit option data MUST be 4-octet aligned.:
 
 ]]></artwork>
           </figure><list style="hanging">
-            <t hangText="Namespace-ID:">16-bit identifier of an IOAM
-            namespace. The Namespace-ID value of 0x0000 is defined as the
+            <t hangText="Namespace-ID:">16-bit identifier of an
+            IOAM-Namespace. The Namespace-ID value of 0x0000 is defined as the
             default value and MUST be known to all the nodes implementing
             IOAM. For any other Namespace-ID value that does not match any
             Namespace-ID the node is configured to operate on, the node MUST
-            NOT change the contents of the IOAM data fields.</t>
+            NOT change the contents of the IOAM-Data-Fields.</t>
 
             <t hangText="IOAM POT Type:">8-bit identifier of a particular POT
             variant that specifies the POT data that is included. This
@@ -1378,24 +1427,25 @@ IOAM proof of transit option of IOAM POT Type 0:
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |        Namespace-ID           |IOAM POT Type=0|P|R R R R R R R|
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+<-+
-|                           Random                              |  |
+|                        Random                                 |  |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+  P
 |                        Random(contd)                          |  O
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+  T
-|                         Cumulative                            |  | 
+|                        Cumulative                             |  | 
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+  |
-|                         Cumulative (contd)                    |  |
+|                        Cumulative (contd)                     |  |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+<-+
 
 
 ]]></artwork>
             </figure><list style="hanging">
-              <t hangText="Namespace-ID:">16-bit identifier of an IOAM
-              namespace. The Namespace-ID value of 0x0000 is defined as the
-              default value and MUST be known to all the nodes implementing
-              IOAM. For any other Namespace-ID value that does not match any
-              Namespace-ID the node is configured to operate on, the node MUST
-              NOT change the contents of the IOAM data fields.</t>
+              <t hangText="Namespace-ID:">16-bit identifier of an
+              IOAM-Namespace. The Namespace-ID value of 0x0000 is defined as
+              the default value and MUST be known to all the nodes
+              implementing IOAM. For any other Namespace-ID value that does
+              not match any Namespace-ID the node is configured to operate on,
+              the node MUST NOT change the contents of the
+              IOAM-Data-Fields.</t>
 
               <t hangText="IOAM POT Type:">8-bit identifier of a particular
               POT variant that specifies the POT data that is included. This
@@ -1427,37 +1477,44 @@ IOAM proof of transit option of IOAM POT Type 0:
         </section>
       </section>
 
-      <section anchor="IOAM_edge_to_edge_opt" title="IOAM Edge-to-Edge Option">
-        <t>The IOAM edge-to-edge option is to carry data that is added by the
-        IOAM encapsulating node and interpreted by IOAM decapsulating node.
-        The IOAM transit nodes MAY process the data without modifying it.</t>
+      <section anchor="IOAM_edge_to_edge_opt"
+               title="IOAM Edge-to-Edge Option-Type">
+        <t>The IOAM Edge-to-Edge Option-Type is to carry data that is added by
+        the IOAM encapsulating node and interpreted by IOAM decapsulating
+        node. The IOAM transit nodes MAY process the data but MUST NOT modify
+        it.</t>
+
+        <t>The IOAM Edge-to-Edge Option-Type consist of a fixed size "IOAM
+        Edge-to-Edge Option-Type header" and "IOAM Edge-to-Edge Option-Type
+        data fields":</t>
 
         <t><figure>
             <artwork><![CDATA[
-  IOAM edge-to-edge option header:
+IOAM Edge-to-Edge Option-Type header:
    
-    0                   1                   2                   3
-    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-   |        Namespace-ID           |         IOAM-E2E-Type         |
-   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ 0                   1                   2                   3
+ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|        Namespace-ID           |         IOAM-E2E-Type         |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 
-   IOAM edge-to-edge option data MUST be 4-octet aligned:
+IOAM Edge-to-Edge Option-Type IOAM-Data-Fields MUST
+be 4-octet aligned:
 
-    0                   1                   2                   3
-    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-   |       E2E Option data field determined by IOAM-E2E-Type       |
-   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ 0                   1                   2                   3
+ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|       E2E Option data field determined by IOAM-E2E-Type       |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 
 ]]></artwork>
           </figure><list style="hanging">
-            <t hangText="Namespace-ID:">16-bit identifier of an IOAM
-            namespace. The Namespace-ID value of 0x0000 is defined as the
+            <t hangText="Namespace-ID:">16-bit identifier of an
+            IOAM-Namespace. The Namespace-ID value of 0x0000 is defined as the
             default value and MUST be known to all the nodes implementing
             IOAM. For any other Namespace-ID value that does not match any
             Namespace-ID the node is configured to operate on, then the node
-            MUST NOT change the contents of the IOAM data fields.</t>
+            MUST NOT change the contents of the IOAM-Data-Fields.</t>
 
             <t hangText="IOAM-E2E-Type:">A 16-bit identifier which specifies
             which data types are used in the E2E option data. The
@@ -1483,33 +1540,30 @@ IOAM proof of transit option of IOAM POT Type 0:
                 <t hangText="Bit 2">When set indicates presence of timestamp
                 seconds for the transmission of the frame. This 4-octet field
                 has three possible formats; based on either PTP <xref
-                target="IEEE1588v2"></xref>, NTP <xref
-                target="RFC5905"></xref>, or POSIX <xref
-                target="POSIX"></xref>. The three timestamp formats are
-                specified in <xref target="TimestampSec"></xref>. In all three
+                target="IEEE1588v2"/>, NTP <xref target="RFC5905"/>, or POSIX
+                <xref target="POSIX"/>. The three timestamp formats are
+                specified in <xref target="TimestampSec"/>. In all three
                 cases, the Timestamp Seconds field contains the 32 most
                 significant bits of the timestamp format that is specified in
-                <xref target="TimestampSec"></xref>. If a node is not capable
-                of populating this field, it assigns the value 0xFFFFFFFF.
-                Note that this is a legitimate value that is valid for 1
-                second in approximately 136 years; the analyzer should
-                correlate several packets or compare the timestamp value to
-                its own time-of-day in order to detect the error
-                indication.</t>
+                <xref target="TimestampSec"/>. If a node is not capable of
+                populating this field, it assigns the value 0xFFFFFFFF. Note
+                that this is a legitimate value that is valid for 1 second in
+                approximately 136 years; the analyzer should correlate several
+                packets or compare the timestamp value to its own time-of-day
+                in order to detect the error indication.</t>
 
                 <t hangText="Bit 3">When set indicates presence of timestamp
                 subseconds for the transmission of the frame. This 4-octet
                 field has three possible formats; based on either PTP <xref
-                target="IEEE1588v2"></xref>, NTP <xref
-                target="RFC5905"></xref>, or POSIX <xref
-                target="POSIX"></xref>. The three timestamp formats are
-                specified in <xref target="TimestampSec"></xref>. In all three
+                target="IEEE1588v2"/>, NTP <xref target="RFC5905"/>, or POSIX
+                <xref target="POSIX"/>. The three timestamp formats are
+                specified in <xref target="TimestampSec"/>. In all three
                 cases, the Timestamp Subseconds field contains the 32 least
                 significant bits of the timestamp format that is specified in
-                <xref target="TimestampSec"></xref>. If a node is not capable
-                of populating this field, it assigns the value 0xFFFFFFFF.
-                Note that this is a legitimate value in the NTP format, valid
-                for approximately 233 picoseconds in every second. If the NTP
+                <xref target="TimestampSec"/>. If a node is not capable of
+                populating this field, it assigns the value 0xFFFFFFFF. Note
+                that this is a legitimate value in the NTP format, valid for
+                approximately 233 picoseconds in every second. If the NTP
                 format is used the analyzer should correlate several packets
                 in order to detect the error indication.</t>
 
@@ -1525,18 +1579,18 @@ IOAM proof of transit option of IOAM POT Type 0:
     </section>
 
     <section anchor="TimestampSec" title="Timestamp Formats">
-      <t>The IOAM data fields include a timestamp field which is represented
+      <t>The IOAM-Data-Fields include a timestamp field which is represented
       in one of three possible timestamp formats. It is assumed that the
       management plane is responsible for determining which timestamp format
       is used.</t>
 
       <section anchor="PTPFromatSec" title="PTP Truncated Timestamp Format">
-        <t>The Precision Time Protocol (PTP) <xref target="IEEE1588v2"></xref>
-        uses an 80-bit timestamp format. The truncated timestamp format is a
-        64-bit field, which is the 64 least significant bits of the 80-bit PTP
+        <t>The Precision Time Protocol (PTP) <xref target="IEEE1588v2"/> uses
+        an 80-bit timestamp format. The truncated timestamp format is a 64-bit
+        field, which is the 64 least significant bits of the 80-bit PTP
         timestamp. The PTP truncated format is specified in Section 4.3 of
-        <xref target="I-D.ietf-ntp-packet-timestamps"></xref>, and the details
-        are presented below for the sake of completeness.</t>
+        <xref target="I-D.ietf-ntp-packet-timestamps"/>, and the details are
+        presented below for the sake of completeness.</t>
 
         <figure align="center" anchor="PTPFormat"
                 title="PTP [IEEE1588v2] Truncated Timestamp Format">
@@ -1570,9 +1624,8 @@ IOAM proof of transit option of IOAM POT Type 0:
           </list></t>
 
         <t>Epoch: <list hangIndent="10" style="empty">
-            <t>The PTP <xref target="IEEE1588v2"></xref> epoch is 1 January
-            1970 00:00:00 TAI, which is 31 December 1969 23:59:51.999918
-            UTC.</t>
+            <t>The PTP <xref target="IEEE1588v2"/> epoch is 1 January 1970
+            00:00:00 TAI, which is 31 December 1969 23:59:51.999918 UTC.</t>
           </list></t>
 
         <t>Resolution: <list hangIndent="10" style="empty">
@@ -1589,9 +1642,9 @@ IOAM proof of transit option of IOAM POT Type 0:
             <t>It is assumed that nodes that run this protocol are
             synchronized among themselves. Nodes may be synchronized to a
             global reference time. Note that if PTP <xref
-            target="IEEE1588v2"></xref> is used for synchronization, the
-            timestamp may be derived from the PTP-synchronized clock, allowing
-            the timestamp to be measured with respect to the clock of an PTP
+            target="IEEE1588v2"/> is used for synchronization, the timestamp
+            may be derived from the PTP-synchronized clock, allowing the
+            timestamp to be measured with respect to the clock of an PTP
             Grandmaster clock.</t>
 
             <t>The PTP truncated timestamp format is not affected by leap
@@ -1600,10 +1653,10 @@ IOAM proof of transit option of IOAM POT Type 0:
       </section>
 
       <section anchor="NTPFormatSec" title="NTP 64-bit Timestamp Format">
-        <t>The Network Time Protocol (NTP) <xref target="RFC5905"></xref>
-        timestamp format is 64 bits long. This format is specified in Section
-        4.2.1 of <xref target="I-D.ietf-ntp-packet-timestamps"></xref>, and
-        the details are presented below for the sake of completeness.</t>
+        <t>The Network Time Protocol (NTP) <xref target="RFC5905"/> timestamp
+        format is 64 bits long. This format is specified in Section 4.2.1 of
+        <xref target="I-D.ietf-ntp-packet-timestamps"/>, and the details are
+        presented below for the sake of completeness.</t>
 
         <figure align="center" anchor="NTPFormat"
                 title="NTP [RFC5905] 64-bit Timestamp Format">
@@ -1652,10 +1705,10 @@ IOAM proof of transit option of IOAM POT Type 0:
 
         <t>Synchronization Aspects: <list hangIndent="10" style="empty">
             <t>Nodes that use this timestamp format will typically be
-            synchronized to UTC using NTP <xref target="RFC5905"></xref>.
-            Thus, the timestamp may be derived from the NTP-synchronized
-            clock, allowing the timestamp to be measured with respect to the
-            clock of an NTP server.</t>
+            synchronized to UTC using NTP <xref target="RFC5905"/>. Thus, the
+            timestamp may be derived from the NTP-synchronized clock, allowing
+            the timestamp to be measured with respect to the clock of an NTP
+            server.</t>
 
             <t>The NTP timestamp format is affected by leap seconds; it
             represents the number of seconds since the epoch minus the number
@@ -1667,8 +1720,8 @@ IOAM proof of transit option of IOAM POT Type 0:
 
       <section anchor="POSIXFormatSec" title="POSIX-based Timestamp Format">
         <t>This timestamp format is based on the POSIX time format <xref
-        target="POSIX"></xref>. The detailed specification of the timestamp
-        format used in this document is presented below.</t>
+        target="POSIX"/>. The detailed specification of the timestamp format
+        used in this document is presented below.</t>
 
         <figure align="center" anchor="POSIXFormat"
                 title="POSIX-based Timestamp Format">
@@ -1721,9 +1774,9 @@ IOAM proof of transit option of IOAM POT Type 0:
             Linux operating system, and hence use the POSIX time. In some
             cases nodes may be synchronized to UTC using a synchronization
             mechanism that is outside the scope of this document, such as NTP
-            <xref target="RFC5905"></xref>. Thus, the timestamp may be derived
-            from the NTP-synchronized clock, allowing the timestamp to be
-            measured with respect to the clock of an NTP server.</t>
+            <xref target="RFC5905"/>. Thus, the timestamp may be derived from
+            the NTP-synchronized clock, allowing the timestamp to be measured
+            with respect to the clock of an NTP server.</t>
 
             <t>The POSIX-based timestamp format is affected by leap seconds;
             it represents the number of seconds since the epoch minus the
@@ -1743,7 +1796,7 @@ IOAM proof of transit option of IOAM POT Type 0:
       outside the scope of this document.</t>
 
       <t>Raw data export of IOAM data using IPFIX is discussed in <xref
-      target="I-D.spiegel-ippm-ioam-rawexport"></xref>.</t>
+      target="I-D.spiegel-ippm-ioam-rawexport"/>.</t>
     </section>
 
     <section anchor="IANA" title="IANA Considerations">
@@ -1753,56 +1806,55 @@ IOAM proof of transit option of IOAM POT Type 0:
                title="Creation of a new In-Situ OAM  Protocol Parameters Registry (IOAM) Protocol Parameters IANA registry">
         <t>IANA is requested to create a new protocol registry for "In-Situ
         OAM (IOAM) Protocol Parameters". This is the common registry that will
-        include registrations for all IOAM namespaces. Each Registry, whose
+        include registrations for all IOAM-Namespaces. Each Registry, whose
         names are listed below:</t>
 
         <t><list style="empty">
-            <t>IOAM Type</t>
+            <t>IOAM Option-Type</t>
 
-            <t>IOAM Trace Type</t>
+            <t>IOAM Trace-Type</t>
 
-            <t>IOAM Trace flags</t>
+            <t>IOAM Trace-Flags</t>
 
-            <t>IOAM POT Type</t>
+            <t>IOAM POT-Type</t>
 
-            <t>IOAM POT flags</t>
+            <t>IOAM POT-Flags</t>
 
-            <t>IOAM E2E Type</t>
+            <t>IOAM E2E-Type</t>
 
             <t>IOAM Namespace-ID</t>
           </list>will contain the current set of possibilities defined in this
         document. New registries in this name space are created via RFC
-        Required process as per <xref target="RFC8126"></xref>.</t>
+        Required process as per <xref target="RFC8126"/>.</t>
 
         <t>The subsequent sub-sections detail the registries herein
         contained.</t>
       </section>
 
-      <section anchor="IOAM-type-registry" title="IOAM Type Registry">
-        <t>This registry defines 128 code points for the IOAM-Type field for
-        identifying IOAM options as explained in <xref
-        target="IOAM_option_format"></xref>. The following code points are
-        defined in this draft:</t>
+      <section anchor="IOAM-type-registry" title="IOAM Option-Type Registry">
+        <t>This registry defines 128 code points for the IOAM Option-Type
+        field for identifying IOAM Option-Types as explained in <xref
+        target="IOAM_option_format"/>. The following code points are defined
+        in this draft:</t>
 
         <t><list style="hanging">
-            <t hangText="0">IOAM Pre-allocated Trace Option Type</t>
+            <t hangText="0">IOAM Pre-allocated Trace Option-Type</t>
 
-            <t hangText="1">IOAM Incremental Trace Option Type</t>
+            <t hangText="1">IOAM Incremental Trace Option-Type</t>
 
-            <t hangText="2">IOAM POT Option Type</t>
+            <t hangText="2">IOAM POT Option-Type</t>
 
-            <t hangText="3">IOAM E2E Option Type</t>
+            <t hangText="3">IOAM E2E Option-Type</t>
           </list>4 - 127 are available for assignment via RFC Required process
-        as per <xref target="RFC8126"></xref>.</t>
+        as per <xref target="RFC8126"/>.</t>
       </section>
 
-      <section title="IOAM Trace Type Registry">
+      <section title="IOAM Trace-Type Registry">
         <t>This registry defines code point for each bit in the 24-bit
         IOAM-Trace-Type field for Pre-allocated trace option and Incremental
-        trace option defined in <xref target="IOAM_tracing_option"></xref>.
-        The meaning of Bits 0 - 11 for trace type are defined in this document
-        in <xref target="IOAMTraceType"></xref> of <xref
-        target="TraceOptionDef"></xref>:</t>
+        trace option defined in <xref target="IOAM_tracing_option"/>. The
+        meaning of Bits 0 - 11 for trace type are defined in this document in
+        <xref target="IOAMTraceType"/> of <xref target="TraceOptionDef"/>:</t>
 
         <t><list style="hanging">
             <t hangText="Bit 0">hop_Lim and node_id in short format</t>
@@ -1820,7 +1872,7 @@ IOAM proof of transit option of IOAM POT Type 0:
 
             <t hangText="Bit 6">queue depth</t>
 
-            <t hangText="Bit 7">variable length Opaque State Snapshot</t>
+            <t hangText="Bit 7">checksum complement</t>
 
             <t hangText="Bit 8">hop_Lim and node_id in wide format</t>
 
@@ -1831,54 +1883,56 @@ IOAM proof of transit option of IOAM POT Type 0:
 
             <t hangText="Bit 11">buffer occupancy</t>
 
-            <t hangText="Bit 23">checksum complement</t>
-          </list> The meaning for Bits 12 - 22 are available for assignment
-        via RFC Required process as per <xref target="RFC8126"></xref>.</t>
+            <t hangText="Bit 22">variable length Opaque State Snapshot</t>
+
+            <t hangText="Bit 23">reserved</t>
+          </list> The meaning for Bits 12 - 21 are available for assignment
+        via RFC Required process as per <xref target="RFC8126"/>.</t>
       </section>
 
-      <section anchor="Flags-Registry-Sec" title="IOAM Trace Flags Registry">
+      <section anchor="Flags-Registry-Sec" title="IOAM Trace-Flags Registry">
         <t>This registry defines code points for each bit in the 4 bit flags
         for the Pre-allocated trace option and for the Incremental trace
-        option defined in <xref target="IOAM_tracing_option"></xref>. The
-        meaning of Bit 0 (the most significant bit) for trace flags is defined
-        in this document in <xref target="TraceFlags"></xref> of <xref
-        target="TraceOptionDef"></xref>:</t>
+        option defined in <xref target="IOAM_tracing_option"/>. The meaning of
+        Bit 0 (the most significant bit) for trace flags is defined in this
+        document in <xref target="TraceFlags"/> of <xref
+        target="TraceOptionDef"/>:</t>
 
         <t><list style="hanging">
             <t hangText="Bit 0">"Overflow" (O-bit)</t>
           </list></t>
       </section>
 
-      <section title="IOAM POT Type Registry">
+      <section title="IOAM POT-Type Registry">
         <t>This registry defines 256 code points to define IOAM POT Type for
         IOAM proof of transit option <xref
-        target="IOAM_proof_of_transit_option"></xref>. The code point value 0
-        is defined in this document:</t>
+        target="IOAM_proof_of_transit_option"/>. The code point value 0 is
+        defined in this document:</t>
 
         <t><list style="hanging">
             <t hangText="0:">16 Octet POT data</t>
           </list> 1 - 255 are available for assignment via RFC Required
-        process as per <xref target="RFC8126"></xref>.</t>
+        process as per <xref target="RFC8126"/>.</t>
       </section>
 
-      <section title="IOAM POT Flags Registry">
+      <section title="IOAM POT-Flags Registry">
         <t>This registry defines code points for each bit in the 8 bit flags
         for IOAM POT option defined in <xref
-        target="IOAM_proof_of_transit_option"></xref>. The meaning of Bit 0
-        for IOAM POT flags is defined in this document in <xref
-        target="IOAM_proof_of_transit_option"></xref>:</t>
+        target="IOAM_proof_of_transit_option"/>. The meaning of Bit 0 for IOAM
+        POT flags is defined in this document in <xref
+        target="IOAM_proof_of_transit_option"/>:</t>
 
         <t><list style="hanging">
             <t hangText="Bit 0">"Profile-to-use" (P-bit)</t>
           </list> The meaning for Bits 1 - 7 are available for assignment via
-        RFC Required process as per <xref target="RFC8126"></xref>.</t>
+        RFC Required process as per <xref target="RFC8126"/>.</t>
       </section>
 
-      <section title="IOAM E2E Type Registry">
+      <section title="IOAM E2E-Type Registry">
         <t>This registry defines code points for each bit in the 16 bit
         IOAM-E2E-Type field for IOAM E2E option <xref
-        target="IOAM_edge_to_edge_opt"></xref>. The meaning of Bit 0 - 3 are
-        defined in this document:</t>
+        target="IOAM_edge_to_edge_opt"/>. The meaning of Bit 0 - 3 are defined
+        in this document:</t>
 
         <t><list style="hanging">
             <t hangText="Bit 0">64-bit sequence number</t>
@@ -1889,7 +1943,7 @@ IOAM proof of transit option of IOAM POT Type 0:
 
             <t hangText="Bit 3">timestamp subseconds</t>
           </list> The meaning of Bits 4 - 15 are available for assignment via
-        RFC Required process as per <xref target="RFC8126"></xref>.</t>
+        RFC Required process as per <xref target="RFC8126"/>.</t>
       </section>
 
       <section title="IOAM Namespace-ID Registry ">
@@ -1897,9 +1951,9 @@ IOAM proof of transit option of IOAM POT Type 0:
         containing 16-bit values. The meaning of Bit 0 is defined in this
         document. IANA is requested to reserve the values 0x0001 to 0x7FFF for
         private use (managed by operators), as specified in <xref
-        target="ioam_namespaces"></xref> of the current document. Registry
-        entries for the values 0x8000 to 0xFFFF are to be assigned via the
-        "Expert Review" policy defined in <xref target="RFC8126"></xref>.</t>
+        target="ioam_namespaces"/> of the current document. Registry entries
+        for the values 0x8000 to 0xFFFF are to be assigned via the "Expert
+        Review" policy defined in <xref target="RFC8126"/>.</t>
 
         <t><list style="hanging">
             <t hangText="0:">default namespace (known to all IOAM nodes)</t>
@@ -1912,15 +1966,15 @@ IOAM proof of transit option of IOAM POT Type 0:
     </section>
 
     <section anchor="Security" title="Security Considerations">
-      <t>As discussed in <xref target="RFC7276"></xref>, a successful attack
-      on an OAM protocol in general, and specifically on IOAM, can prevent the
+      <t>As discussed in <xref target="RFC7276"/>, a successful attack on an
+      OAM protocol in general, and specifically on IOAM, can prevent the
       detection of failures or anomalies, or create a false illusion of
       nonexistent ones.</t>
 
-      <t>The Proof of Transit option (Section <xref
-      target="IOAM_proof_of_transit_option"></xref>) is used for verifying the
-      path of data packets. The security considerations of POT are further
-      discussed in <xref target="I-D.brockners-proof-of-transit"></xref>.</t>
+      <t>The Proof of Transit Option-Type (Section <xref
+      target="IOAM_proof_of_transit_option"/>) is used for verifying the path
+      of data packets. The security considerations of POT are further
+      discussed in <xref target="I-D.ietf-sfc-proof-of-transit"/>.</t>
 
       <t>The data elements of IOAM can be used for network reconnaissance,
       allowing attackers to collect information about network paths,
@@ -1936,14 +1990,14 @@ IOAM proof of transit option of IOAM POT Type 0:
       add an IOAM header to packets in order to consume the resources of
       network devices that take part in IOAM or collectors that analyze the
       IOAM data. Another example is a packet length attack, in which an
-      attacker pushes IOAM headers into data packets, causing these packets to
-      be increased beyond the MTU size, resulting in fragmentation or in
-      packet drops.</t>
+      attacker pushes headers associated with IOAM Option-Types into data
+      packets, causing these packets to be increased beyond the MTU size,
+      resulting in fragmentation or in packet drops.</t>
 
       <t>Since IOAM options may include timestamps, if network devices use
       synchronization protocols then any attack on the time protocol <xref
-      target="RFC7384"></xref> can compromise the integrity of the
-      timestamp-related data fields.</t>
+      target="RFC7384"/> can compromise the integrity of the timestamp-related
+      data fields.</t>
 
       <t>At the management plane, attacks may be implemented by misconfiguring
       or by maliciously configuring IOAM-enabled nodes in a way that enables
@@ -1966,11 +2020,11 @@ IOAM proof of transit option of IOAM POT Type 0:
       <t>The authors would like to thank Eric Vyncke, Nalini Elkins, Srihari
       Raghavan, Ranganathan T S, Karthik Babu Harichandra Babu, Akshaya
       Nadahalli, LJ Wobker, Erik Nordmark, Vengada Prasad Govindan, Andrew
-      Yourtchenko, Aviv Kfir, Tianran Zhou, Haoyu song and Robin
-      &lt;lizhenbin@huawei.com&gt; for the comments and advice.</t>
+      Yourtchenko, Aviv Kfir, Tianran Zhou, Haoyu song and Zhenbin (Robin) for
+      the comments and advice.</t>
 
       <t>This document leverages and builds on top of several concepts
-      described in <xref target="I-D.kitamura-ipv6-record-route"></xref>. The
+      described in <xref target="I-D.kitamura-ipv6-record-route"/>. The
       authors would like to acknowledge the work done by the author Hiroshi
       Kitamura and people involved in writing it.</t>
 
@@ -2018,10 +2072,10 @@ IOAM proof of transit option of IOAM POT Type 0:
             Engineers</organization>
           </author>
 
-          <date year="2008" />
+          <date year="2008"/>
         </front>
 
-        <seriesInfo name="" value="IEEE Std 1003.1-2008" />
+        <seriesInfo name="" value="IEEE Std 1003.1-2008"/>
       </reference>
 
       <reference anchor="IEEE1588v2"
@@ -2036,10 +2090,10 @@ IOAM proof of transit option of IOAM POT Type 0:
             Engineers</organization>
           </author>
 
-          <date year="2008" />
+          <date year="2008"/>
         </front>
 
-        <seriesInfo name="" value="IEEE Std 1588-2008" />
+        <seriesInfo name="" value="IEEE Std 1588-2008"/>
       </reference>
     </references>
 
@@ -2063,16 +2117,16 @@ IOAM proof of transit option of IOAM POT Type 0:
           <title>Record Route for IPv6 (PR6) Hop-by-Hop Option
           Extension</title>
 
-          <author fullname="Hiroshi Kitamura" initials="H" surname="Kitamura"></author>
+          <author fullname="Hiroshi Kitamura" initials="H" surname="Kitamura"/>
 
-          <date month="November" year="2000" />
+          <date month="November" year="2000"/>
         </front>
 
         <seriesInfo name="Internet-Draft"
-                    value="draft-kitamura-ipv6-record-route-00" />
+                    value="draft-kitamura-ipv6-record-route-00"/>
 
         <format target="https://tools.ietf.org/id/draft-kitamura-ipv6-record-route-00.txt"
-                type="TXT" />
+                type="TXT"/>
       </reference>
 
       &RFC8300;
@@ -2083,7 +2137,7 @@ IOAM proof of transit option of IOAM POT Type 0:
 
       &I-D.ietf-ntp-packet-timestamps;
 
-      &I-D.brockners-proof-of-transit;
+      &I-D.ietf-sfc-proof-of-transit;
 
       &I-D.spiegel-ippm-ioam-rawexport;
     </references>

--- a/drafts/versions/07/draft-ietf-ippm-ioam-data-07.txt
+++ b/drafts/versions/07/draft-ietf-ippm-ioam-data-07.txt
@@ -1,0 +1,2296 @@
+
+
+
+
+ippm                                                        F. Brockners
+Internet-Draft                                               S. Bhandari
+Intended status: Standards Track                            C. Pignataro
+Expires: March 6, 2020                                             Cisco
+                                                              H. Gredler
+                                                            RtBrick Inc.
+                                                                J. Leddy
+
+                                                               S. Youell
+                                                                    JPMC
+                                                              T. Mizrahi
+                                        Huawei Network.IO Innovation Lab
+                                                                D. Mozes
+
+                                                             P. Lapukhov
+                                                                Facebook
+                                                                R. Chang
+                                                       Barefoot Networks
+                                                              D. Bernier
+                                                             Bell Canada
+                                                                J. Lemon
+                                                                Broadcom
+                                                      September 03, 2019
+
+
+                      Data Fields for In-situ OAM
+                      draft-ietf-ippm-ioam-data-07
+
+Abstract
+
+   In-situ Operations, Administration, and Maintenance (IOAM) records
+   operational and telemetry information in the packet while the packet
+   traverses a path between two points in the network.  This document
+   discusses the data fields and associated data types for in-situ OAM.
+   In-situ OAM data fields can be embedded into a variety of transports
+   such as NSH, Segment Routing, Geneve, native IPv6 (via extension
+   header), or IPv4.  In-situ OAM can be used to complement OAM
+   mechanisms based on e.g.  ICMP or other types of probe packets.
+
+Status of This Memo
+
+   This Internet-Draft is submitted in full conformance with the
+   provisions of BCP 78 and BCP 79.
+
+   Internet-Drafts are working documents of the Internet Engineering
+   Task Force (IETF).  Note that other groups may also distribute
+   working documents as Internet-Drafts.  The list of current Internet-
+   Drafts is at https://datatracker.ietf.org/drafts/current/.
+
+
+
+Brockners, et al.         Expires March 6, 2020                 [Page 1]
+
+Internet-Draft           In-situ OAM Data Fields          September 2019
+
+
+   Internet-Drafts are draft documents valid for a maximum of six months
+   and may be updated, replaced, or obsoleted by other documents at any
+   time.  It is inappropriate to use Internet-Drafts as reference
+   material or to cite them other than as "work in progress."
+
+   This Internet-Draft will expire on March 6, 2020.
+
+Copyright Notice
+
+   Copyright (c) 2019 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (https://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+Table of Contents
+
+   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   3
+   2.  Conventions . . . . . . . . . . . . . . . . . . . . . . . . .   3
+   3.  Scope, Applicability, and Assumptions . . . . . . . . . . . .   4
+   4.  IOAM Data-Fields, Types, Nodes  . . . . . . . . . . . . . . .   5
+     4.1.  IOAM Data-Fields and Option-Types . . . . . . . . . . . .   5
+     4.2.  IOAM-Domains and types of IOAM Nodes  . . . . . . . . . .   6
+     4.3.  IOAM-Namespaces . . . . . . . . . . . . . . . . . . . . .   7
+     4.4.  IOAM Trace Option-Types . . . . . . . . . . . . . . . . .   9
+       4.4.1.  Pre-allocated and Incremental Trace Option-Types  . .  11
+       4.4.2.  IOAM node data fields and associated formats  . . . .  15
+       4.4.3.  Examples of IOAM node data  . . . . . . . . . . . . .  21
+     4.5.  IOAM Proof of Transit Option-Type . . . . . . . . . . . .  23
+       4.5.1.  IOAM Proof of Transit Type 0  . . . . . . . . . . . .  25
+     4.6.  IOAM Edge-to-Edge Option-Type . . . . . . . . . . . . . .  26
+   5.  Timestamp Formats . . . . . . . . . . . . . . . . . . . . . .  28
+     5.1.  PTP Truncated Timestamp Format  . . . . . . . . . . . . .  28
+     5.2.  NTP 64-bit Timestamp Format . . . . . . . . . . . . . . .  29
+     5.3.  POSIX-based Timestamp Format  . . . . . . . . . . . . . .  30
+   6.  IOAM Data Export  . . . . . . . . . . . . . . . . . . . . . .  32
+   7.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  32
+     7.1.  Creation of a new In-Situ OAM  Protocol Parameters
+           Registry (IOAM) Protocol Parameters IANA registry . . . .  32
+     7.2.  IOAM Option-Type Registry . . . . . . . . . . . . . . . .  33
+     7.3.  IOAM Trace-Type Registry  . . . . . . . . . . . . . . . .  33
+
+
+
+Brockners, et al.         Expires March 6, 2020                 [Page 2]
+
+Internet-Draft           In-situ OAM Data Fields          September 2019
+
+
+     7.4.  IOAM Trace-Flags Registry . . . . . . . . . . . . . . . .  34
+     7.5.  IOAM POT-Type Registry  . . . . . . . . . . . . . . . . .  34
+     7.6.  IOAM POT-Flags Registry . . . . . . . . . . . . . . . . .  34
+     7.7.  IOAM E2E-Type Registry  . . . . . . . . . . . . . . . . .  35
+     7.8.  IOAM Namespace-ID Registry  . . . . . . . . . . . . . . .  35
+   8.  Security Considerations . . . . . . . . . . . . . . . . . . .  35
+   9.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  36
+   10. References  . . . . . . . . . . . . . . . . . . . . . . . . .  37
+     10.1.  Normative References . . . . . . . . . . . . . . . . . .  37
+     10.2.  Informative References . . . . . . . . . . . . . . . . .  37
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  39
+
+1.  Introduction
+
+   This document defines data fields for "in-situ" Operations,
+   Administration, and Maintenance (IOAM).  In-situ OAM records OAM
+   information within the packet while the packet traverses a particular
+   network domain.  The term "in-situ" refers to the fact that the OAM
+   data is added to the data packets rather than is being sent within
+   packets specifically dedicated to OAM.  IOAM is to complement
+   mechanisms such as Ping or Traceroute, or more recent active probing
+   mechanisms as described in [I-D.lapukhov-dataplane-probe].  In terms
+   of "active" or "passive" OAM, "in-situ" OAM can be considered a
+   hybrid OAM type.  "In-situ" mechanisms do not require extra packets
+   to be sent.  IOAM adds information to the already available data
+   packets and therefore cannot be considered passive.  In terms of the
+   classification given in [RFC7799] IOAM could be portrayed as Hybrid
+   Type 1.  IOAM mechanisms can be leveraged where mechanisms using e.g.
+   ICMP do not apply or do not offer the desired results, such as
+   proving that a certain traffic flow takes a pre-defined path, SLA
+   verification for the live data traffic, detailed statistics on
+   traffic distribution paths in networks that distribute traffic across
+   multiple paths, or scenarios in which probe traffic is potentially
+   handled differently from regular data traffic by the network devices.
+
+2.  Conventions
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in [RFC2119].
+
+   Abbreviations used in this document:
+
+   E2E        Edge to Edge
+
+   Geneve:    Generic Network Virtualization Encapsulation
+              [I-D.ietf-nvo3-geneve]
+
+
+
+
+Brockners, et al.         Expires March 6, 2020                 [Page 3]
+
+Internet-Draft           In-situ OAM Data Fields          September 2019
+
+
+   IOAM:      In-situ Operations, Administration, and Maintenance
+
+   MTU:       Maximum Transmit Unit
+
+   NSH:       Network Service Header [RFC8300]
+
+   OAM:       Operations, Administration, and Maintenance
+
+   POT:       Proof of Transit
+
+   SFC:       Service Function Chain
+
+   SID:       Segment Identifier
+
+   SR:        Segment Routing
+
+   VXLAN-GPE: Virtual eXtensible Local Area Network, Generic Protocol
+              Extension [I-D.ietf-nvo3-vxlan-gpe]
+
+3.  Scope, Applicability, and Assumptions
+
+   IOAM deployment assumes a set of constraints, requirements, and
+   guiding principles which are described in this section.
+
+   Scope: This document defines the data fields and associated data
+   types for in-situ OAM.  The in-situ OAM data field can be transported
+   by a variety of transport protocols, including NSH, Segment Routing,
+   Geneve, IPv6, or IPv4.  Specification details for these different
+   transport protocols are outside the scope of this document.
+
+   Deployment domain (or scope) of in-situ OAM deployment: IOAM is a
+   network domain focused feature, with "network domain" being a set of
+   network devices or entities within a single administration.  For
+   example, a network domain can include an enterprise campus using
+   physical connections between devices or an overlay network using
+   virtual connections / tunnels for connectivity between said devices.
+   A network domain is defined by its perimeter or edge.  Designers of
+   protocol encapsulations for IOAM must specify mechanisms to ensure
+   that IOAM data stays within an IOAM domain.  In addition, the
+   operator of such a domain is expected to put provisions in place to
+   ensure that IOAM data does not leak beyond the edge of an IOAM
+   domain, e.g. using for example packet filtering methods.  The
+   operator should consider the potential operational impact of IOAM to
+   mechanisms such as ECMP processing (e.g.  load-balancing schemes
+   based on packet length could be impacted by the increased packet size
+   due to IOAM), path MTU (i.e. ensure that the MTU of all links within
+   a domain is sufficiently large to support the increased packet size
+   due to IOAM) and ICMP message handling (i.e. in case of a native IPv6
+
+
+
+Brockners, et al.         Expires March 6, 2020                 [Page 4]
+
+Internet-Draft           In-situ OAM Data Fields          September 2019
+
+
+   transport, IOAM support for ICMPv6 Echo Request/Reply could desired
+   which would translate into ICMPv6 extensions to enable IOAM-Data-
+   Fields to be copied from an Echo Request message to an Echo Reply
+   message).
+
+   IOAM control points: IOAM-Data-Fields are added to or removed from
+   the live user traffic by the devices which form the edge of a domain.
+   Devices which form an IOAM-Domain can add, update or remove IOAM-
+   Data-Fields.  Edge devices of an IOAM-Domain can be hosts or network
+   devices.
+
+   Traffic-sets that IOAM is applied to: IOAM can be deployed on all or
+   only on subsets of the live user traffic.  It SHOULD be possible to
+   enable IOAM on a selected set of traffic (e.g., per interface, based
+   on an access control list or flow specification defining a specific
+   set of traffic, etc.)  The selected set of traffic can also be all
+   traffic.
+
+   Encapsulation independence: Data formats for IOAM SHOULD be defined
+   in a transport-independent manner.  IOAM applies to a variety of
+   encapsulating protocols.  A definition of how IOAM-Data-Fields are
+   encapsulated into "parent" protocols, like NSH or IPv6 is outside the
+   scope of this document.
+
+   Layering: If several encapsulation protocols (e.g., in case of
+   tunneling) are stacked on top of each other, IOAM-Data-Fields could
+   be present at multiple layers.  The behavior follows the ships-in-
+   the-night model, i.e. IOAM-Data-Fields in one layer are independent
+   from IOAM-Data-Fields in another layer.  Layering allows operators to
+   instrument the protocol layer they want to measure.  The different
+   layers could, but do not have to share the same IOAM encapsulation
+   mechanisms.
+
+   IOAM implementation: The definition of the IOAM-Data-Fields take the
+   specifics of devices with hardware data-plane and software data-plane
+   into account.
+
+4.  IOAM Data-Fields, Types, Nodes
+
+   This section details IOAM-related nomenclature and describes data
+   types such as IOAM-Data-Fields, IOAM-Types, IOAM-Namespaces as well
+   as the different types of IOAM nodes.
+
+4.1.  IOAM Data-Fields and Option-Types
+
+   An IOAM-Data-Field is a set of bits with a defined format and
+   meaning, which can be stored at a certain place in a packet for the
+   purpose of IOAM.
+
+
+
+Brockners, et al.         Expires March 6, 2020                 [Page 5]
+
+Internet-Draft           In-situ OAM Data Fields          September 2019
+
+
+   To accommodate the different uses of IOAM, IOAM-Data-Fields fall into
+   different categories.  In IOAM these categories are referred to as
+   IOAM-Option-Types.  A common registry is maintained for IOAM-Option-
+   Types, see Section 7.2 for details.  Corresponding to these IOAM-
+   Option-Types, different IOAM-Data-Fields are defined.  IOAM-Data-
+   Fields can be encapsulated into a variety of protocols, such as NSH,
+   Geneve, IPv6, etc.  The definition of how IOAM-Data-Fields are
+   encapsulated into other protocols is outside the scope of this
+   document.
+
+   This document defines four IOAM-Option-Types:
+
+   o  Pre-allocated Trace Option-Type
+
+   o  Incremental Trace Option-Type
+
+   o  Proof of Transit (POT) Option-Type
+
+   o  Edge-to-Edge (E2E) Option-Type
+
+4.2.  IOAM-Domains and types of IOAM Nodes
+
+   IOAM is expected to be deployed in a specific domain.  The part of
+   the network which employs IOAM is referred to as the "IOAM-Domain".
+   One or more IOAM-Option-Types are added to a packet upon entering the
+   IOAM-Domain and are removed from the packet when exiting the domain.
+   Within the IOAM-Domain, the IOAM-Data-Fields MAY be updated by
+   network nodes that the packet traverses.  An IOAM-Domain consists of
+   "IOAM encapsulating nodes", "IOAM decapsulating nodes" and "IOAM
+   transit nodes".  The role of a node (i.e. encapsulating, transit,
+   decapsulating) is defined within an IOAM-Namespace (see below).  A
+   node can have different roles in different IOAM-Namespaces.
+
+   A device which adds at least one IOAM-Option-Type to the packet is
+   called the "IOAM encapsulating node", whereas a device which removes
+   an IOAM-Option-Type is referred to as the "IOAM decapsulating node".
+   Nodes within the domain which are aware of IOAM data and read and/or
+   write or process the IOAM data are called "IOAM transit nodes".  IOAM
+   nodes which add or remove the IOAM-Data-Fields can also update the
+   IOAM-Data-Fields at the same time.  Or in other words, IOAM
+   encapsulating or decapsulating nodes can also serve as IOAM transit
+   nodes at the same time.  Note that not every node in an IOAM domain
+   needs to be an IOAM transit node.  For example, a deployment might
+   require that packets traverse a set of firewalls which support IOAM.
+   In that case, only the set of firewall nodes would be IOAM transit
+   nodes rather than all nodes.
+
+
+
+
+
+Brockners, et al.         Expires March 6, 2020                 [Page 6]
+
+Internet-Draft           In-situ OAM Data Fields          September 2019
+
+
+   An "IOAM encapsulating node" incorporates one or more IOAM-Option-
+   Types (from the list of IOAM-Types, see Section 7.2) into packets
+   that IOAM is enabled for.  If IOAM is enabled for a selected subset
+   of the traffic, the IOAM encapsulating node is responsible for
+   applying the IOAM functionality to the selected subset.
+
+   An "IOAM transit node" updates one or more of the IOAM-Data-Fields.
+   If both the Pre-allocated and the Incremental Trace Option-Types are
+   present in the packet, each IOAM transit node will update at most one
+   of these Option-Types.  A transit node MUST NOT add new IOAM-Option-
+   Types to a packet, and MUST NOT change the IOAM-Data-Fields of an
+   IOAM Edge-to-Edge Option-Type.
+
+   An "IOAM decapsulating node" removes IOAM-Option-Type(s) from
+   packets.
+
+4.3.  IOAM-Namespaces
+
+   A subset or all of the IOAM-Option-Types and their corresponding
+   IOAM-Data-Fields can be associated to an IOAM-Namespace.  IOAM-
+   Namespaces add further context to IOAM-Option-Types and associated
+   IOAM-Data-Fields.  Any IOAM-Namespace MUST interpret the IOAM-Option-
+   Types and associated IOAM-Data-Fields per the definition in this
+   document.  IOAM-Namespaces group nodes to support different
+   deployment approaches of IOAM (see a few example use-cases below) as
+   well as resolve issues which can occur due to IOAM-Data-Fields not
+   being globally unique (e.g.  IOAM node identifiers do not have to be
+   globally unique).  IOAM-Data-Fields significance is always within a
+   particular IOAM-Namespace.
+
+   An IOAM-Namespace is identified by a 16-bit namespace identifier
+   (Namespace-ID).  IOAM-Namespace identifiers MUST be present and
+   populated in all IOAM-Option-Types.  The Namespace-ID value is
+   divided into two sub-ranges:
+
+   o  An operator-assigned range from 0x0001 to 0x7FFF
+
+   o  An IANA-assigned range from 0x8000 to 0xFFFF
+
+   The IANA-assigned range is intended to allow future extensions to
+   have new and interoperable IOAM functionality, while the operator-
+   assigned range is intended to be domain specific, and managed by the
+   network operator.  The Namespace-ID value of 0x0000 is default and
+   known to all the nodes implementing IOAM.
+
+   Namespace identifiers allow devices which are IOAM capable to
+   determine:
+
+
+
+
+Brockners, et al.         Expires March 6, 2020                 [Page 7]
+
+Internet-Draft           In-situ OAM Data Fields          September 2019
+
+
+   o  whether IOAM-Option-Type(s) need to be processed by a device: If
+      the Namespace-ID contained in a packet does not match any
+      Namespace-ID the node is configured to operate on, then the node
+      MUST NOT change the contents of the IOAM-Data-Fields.
+
+   o  which IOAM-Option-Type needs to be processed/updated in case there
+      are multiple IOAM-Option-Types present in the packet.  Multiple
+      IOAM-Option-Types can be present in a packet in case of
+      overlapping IOAM-Domains or in case of a layered IOAM deployment.
+
+   o  whether IOAM-Option-Type(s) should be removed from the packet,
+      e.g. at a domain edge or domain boundary.
+
+   IOAM-Namespaces support several different uses:
+
+   o  IOAM-Namespaces can be used by an operator to distinguish
+      different operational domains.  Devices at domain edges can filter
+      on Namespace-IDs to provide for proper IOAM-Domain isolation.
+
+   o  IOAM-Namespaces provide additional context for IOAM-Data-Fields
+      and thus ensure that IOAM-Data-Fields are unique and can be
+      interpreted properly by management stations or network
+      controllers.  While, for example, the node identifier field
+      (node_id, see below) does not need to be unique in a deployment
+      (e.g. an operator may wish to use different node identifiers for
+      different IOAM layers, even within the same device; or node
+      identifiers might not be unique for other organizational reasons,
+      such as after a merger of two formerly separated organizations),
+      the combination of node_id and Namespace-ID will always be unique.
+      Similarly, IOAM-Namespaces can be used to define how certain IOAM-
+      Data-Fields are interpreted: IOAM offers three different timestamp
+      format options.  The Namespace-ID can be used to determine the
+      timestamp format.  IOAM-Data-Fields (e.g. buffer occupancy) which
+      do not have a unit associated are to be interpreted within the
+      context of a IOAM-Namespace.
+
+   o  IOAM-Namespaces can be used to identify different sets of devices
+      (e.g., different types of devices) in a deployment: If an operator
+      desires to insert different IOAM-Data-Fields based on the device,
+      the devices could be grouped into multiple IOAM-Namespaces.  This
+      could be due to the fact that the IOAM feature set differs between
+      different sets of devices, or it could be for reasons of optimized
+      space usage in the packet header.  It could also stem from
+      hardware or operational limitations on the size of the trace data
+      that can be added and processed, preventing collection of a full
+      trace for a flow.
+
+
+
+
+
+Brockners, et al.         Expires March 6, 2020                 [Page 8]
+
+Internet-Draft           In-situ OAM Data Fields          September 2019
+
+
+      *  Assigning different IOAM Namespace-IDs to different sets of
+         nodes or network partitions and using the Namespace-ID as a
+         selector at the IOAM encapsulating node, a full trace for a
+         flow could be collected and constructed via partial traces in
+         different packets of the same flow.  Example: An operator could
+         choose to group the devices of a domain into two IOAM-
+         Namespaces, in a way that at average, only every second hop
+         would be recorded by any device.  To retrieve a full view of
+         the deployment, the captured IOAM-Data-Fields of the two IOAM-
+         Namespaces need to be correlated.
+
+      *  Assigning different IOAM Namespace-IDs to different sets of
+         nodes or network partitions and using a separate instance of an
+         IOAM-Option-Type for each Namespace-ID, a full trace for a flow
+         could be collected and constructed via partial traces from each
+         IOAM-Option-Type in each of the packets in the flow.  Example:
+         An operator could choose to group the devices of a domain into
+         two IOAM-Namespaces, in a way that each IOAM-Namespace is
+         represented by one of two IOAM-Option-Types in the packet.
+         Each node would record data only for the IOAM-Namespace that it
+         belongs to, ignoring the other IOAM-Option-Type with a IOAM-
+         Namespace to which it doesn't belong.  To retrieve a full view
+         of the deployment, the captured IOAM-Data-Fields of the two
+         IOAM-Namespaces need to be correlated.
+
+4.4.  IOAM Trace Option-Types
+
+   "IOAM tracing data" is expected to be collected at every IOAM transit
+   node that a packet traverses to ensure visibility into the entire
+   path a packet takes within an IOAM-Domain.  I.e., in a typical
+   deployment all nodes in an IOAM-Domain would participate in IOAM and
+   thus be IOAM transit nodes, IOAM encapsulating or IOAM decapsulating
+   nodes.  If not all nodes within a domain are IOAM capable, IOAM
+   tracing information (i.e., node data, see below) will only be
+   collected on those nodes which are IOAM capable.  Nodes which are not
+   IOAM capable will forward the packet without any changes to the IOAM-
+   Data-Fields.  The maximum number of hops and the minimum path MTU of
+   the IOAM domain is assumed to be known.
+
+   To optimize hardware and software implementations IOAM tracing is
+   defined as two separate options.  Any deployment MAY choose to
+   configure and support one or both of the following options.
+
+   Pre-allocated Trace-Option:  This trace option is defined as a
+      container of node data fields (see below) with pre-allocated space
+      for each node to populate its information.  This option is useful
+      for implementations where it is efficient to allocate the space
+      once and index into the array to populate the data during transit
+
+
+
+Brockners, et al.         Expires March 6, 2020                 [Page 9]
+
+Internet-Draft           In-situ OAM Data Fields          September 2019
+
+
+      (e.g., software forwarders often fall into this class).  The IOAM
+      encapsulating node allocates space for Pre-allocated Trace Option-
+      Type in the packet and sets corresponding fields in this IOAM-
+      Option-Type.  The IOAM encapsulating node allocates an array which
+      is used to store operational data retrieved from every node while
+      the packet traverses the domain.  IOAM transit nodes update the
+      content of the array, and possibly update the checksums of outer
+      headers.  A pointer which is part of the IOAM trace data, points
+      to the next empty slot in the array.  An IOAM transit node that
+      updates the content of the pre-allocated option also updates the
+      value of the pointer, which specifies where the next IOAM transit
+      node fills in its data.The "node data list" array (see below) in
+      the packet is populated iteratively as the packet traverses the
+      network, starting with the last entry of the array, i.e., "node
+      data list [n]" is the first entry to be populated, "node data list
+      [n-1]" is the second one, etc.
+
+   Incremental Trace-Option:  This trace option is defined as a
+      container of node data fields where each node allocates and pushes
+      its node data immediately following the option header.  This type
+      of trace recording is useful for some of the hardware
+      implementations as it eliminates the need for the transit network
+      elements to read the full array in the option and allows for
+      arbitrarily long packets as the MTU allows.  The IOAM
+      encapsulating node allocates space for the Incremental Trace
+      Option-Type.  Based on operational state and configuration, the
+      IOAM encapsulating node sets the fields in the Option-Type that
+      control what IOAM-Data-Fields should be collected and how large
+      the node data list can grow.  IOAM transit nodes push their node
+      data to the node data list, decrease the remaining length
+      available to subsequent nodes and adjust the lengths and possibly
+      checksums in outer headers.
+
+   A particular implementation of IOAM MAY choose to support only one of
+   the two trace option types.  In the event that both options are
+   utilized at the same time, the Incremental Trace-Option MUST be
+   placed before the Pre-allocated Trace-Option.  Deployments which mix
+   devices which either the Incremental Trace-Option or the Pre-
+   allocated Trace-Option could result in both Option-Types being
+   present in a packet.  Given that the operator knows which equipment
+   is deployed in a particular IOAM, the operator will decide by means
+   of configuration which type(s) of trace options will be used for a
+   particular domain.
+
+   Every node data entry holds information for a particular IOAM transit
+   node that is traversed by a packet.  The IOAM decapsulating node
+   removes the IOAM-Option-Type(s) and processes and/or exports the
+   associated data.  IOAM-Data-Fields are defined in the context of an
+
+
+
+Brockners, et al.         Expires March 6, 2020                [Page 10]
+
+Internet-Draft           In-situ OAM Data Fields          September 2019
+
+
+   IOAM-Namespace.  This allows for a namespace-specific definition and
+   interpretation.  For example: In one case an interface-id could point
+   to a physical interface (e.g., to understand which physical interface
+   of an aggregated link is used when receiving or transmitting a
+   packet) whereas in another case it could refer to a logical interface
+   (e.g., in case of tunnels).
+
+   IOAM tracing can collect the following types of information:
+
+   o  Identification of the IOAM node.  An IOAM node identifier can
+      match to a device identifier or a particular control point or
+      subsystem within a device.
+
+   o  Identification of the interface that a packet was received on,
+      i.e. ingress interface.
+
+   o  Identification of the interface that a packet was sent out on,
+      i.e. egress interface.
+
+   o  Time of day when the packet was processed by the node as well as
+      the transit delay.  Different definitions of processing time are
+      feasible and expected, though it is important that all devices of
+      an in-situ OAM domain follow the same definition.
+
+   o  Generic data: Format-free information where syntax and semantic of
+      the information is defined by the operator in a specific
+      deployment.  For a specific IOAM-Namespace, all IOAM nodes should
+      interpret the generic data the same way.  Examples for generic
+      IOAM data include geo-location information (location of the node
+      at the time the packet was processed), buffer queue fill level or
+      cache fill level at the time the packet was processed, or even a
+      battery charge level.
+
+   o  Information to detect whether IOAM trace data was added at every
+      hop or whether certain hops in the domain weren't IOAM transit
+      nodes.
+
+4.4.1.  Pre-allocated and Incremental Trace Option-Types
+
+   The IOAM Pre-allocated Trace-Option and the IOAM Incremental Trace-
+   Option have similar formats.  Except where noted below, the internal
+   formats and fields of the two trace options are identical.  Both
+   Trace-Options consist of a fixed size "trace option header" and a
+   variable data space to store gathered data, the "node data list":
+
+
+
+
+
+
+
+Brockners, et al.         Expires March 6, 2020                [Page 11]
+
+Internet-Draft           In-situ OAM Data Fields          September 2019
+
+
+   Pre-allocated and incremental trace option headers:
+
+    0                   1                   2                   3
+    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |        Namespace-ID           |NodeLen  | Flags | RemainingLen|
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |               IOAM-Trace-Type                 |  Reserved     |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+
+   The trace option data MUST be 4-octet aligned:
+
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+<-+
+   |                                                               |  |
+   |                        node data list [0]                     |  |
+   |                                                               |  |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+  D
+   |                                                               |  a
+   |                        node data list [1]                     |  t
+   |                                                               |  a
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   ~                             ...                               ~  S
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+  p
+   |                                                               |  a
+   |                        node data list [n-1]                   |  c
+   |                                                               |  e
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+  |
+   |                                                               |  |
+   |                        node data list [n]                     |  |
+   |                                                               |  |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+<-+
+
+
+
+   Namespace-ID:  16-bit identifier of an IOAM-Namespace.  The
+      Namespace-ID value of 0x0000 is defined as the default value and
+      MUST be known to all the nodes implementing IOAM.  For any other
+      Namespace-ID value that does not match any Namespace-ID the node
+      is configured to operate on, the node MUST NOT change the contents
+      of the IOAM-Data-Fields.
+
+   NodeLen:  5-bit unsigned integer.  This field specifies the length of
+      data added by each node in multiples of 4-octets, excluding the
+      length of the "Opaque State Snapshot" field.
+
+      If IOAM-Trace-Type bit 22 is not set, then NodeLen specifies the
+      actual length added by each node.  If IOAM-Trace-Type bit 22 is
+
+
+
+Brockners, et al.         Expires March 6, 2020                [Page 12]
+
+Internet-Draft           In-situ OAM Data Fields          September 2019
+
+
+      set, then the actual length added by a node would be (NodeLen +
+      Opaque Data Length).
+
+      For example, if 3 IOAM-Trace-Type bits are set and none of them
+      are wide, then NodeLen would be 3.  If 3 IOAM-Trace-Type bits are
+      set and 2 of them are wide, then NodeLen would be 5.
+
+      An IOAM encapsulating node must set NodeLen.
+
+      A node receiving an IOAM Pre-allocated or Incremental Trace-Option
+      may rely on the NodeLen value, or it may ignore the NodeLen value
+      and calculate the node length from the IOAM-Trace-Type bits (see
+      below).
+
+   Flags  4-bit field.  Flags are allocated by IANA, as specified in
+      Section 7.4.  This document allocates a single flag as follows:
+
+      Bit 0  "Overflow" (O-bit) (most significant bit).  This bit is set
+         by the network element if there are not enough octets left to
+         record node data, no field is added and the overflow "O-bit"
+         must be set to "1" in the IOAM-Trace-Option header.  This is
+         useful for transit nodes to ignore further processing of the
+         option.
+
+   RemainingLen:  7-bit unsigned integer.  This field specifies the data
+      space in multiples of 4-octets remaining for recording the node
+      data, before the node data list is considered to have overflowed.
+      When RemainingLen reaches 0, nodes are no longer allowed to add
+      node data.  Given that the sender knows the minimum path MTU, the
+      sender MAY set the initial value of RemainingLen according to the
+      number of node data bytes allowed before exceeding the MTU.
+      Subsequent nodes can carry out a simple comparison between
+      RemainingLen and NodeLen, along with the length of the "Opaque
+      State Snapshot" if applicable, to determine whether or not data
+      can be added by this node.  When node data is added, the node MUST
+      decrease RemainingLen by the amount of data added.  In the pre-
+      allocated trace option, RemainingLength is used to derive the
+      offset in data space to record the node data element.
+      Specifically, the recording of the node data element would start
+      from RemainingLen - NodeLen - sizeof(opaque snapshot) in 4 octet
+      units.
+
+   IOAM-Trace-Type:  A 24-bit identifier which specifies which data
+      types are used in this node data list.
+
+      The IOAM-Trace-Type value is a bit field.  The following bits are
+      defined in this document, with details on each bit described in
+      the Section 4.4.2.  The order of packing the data fields in each
+
+
+
+Brockners, et al.         Expires March 6, 2020                [Page 13]
+
+Internet-Draft           In-situ OAM Data Fields          September 2019
+
+
+      node data element follows the bit order of the IOAM-Trace-Type
+      field, as follows:
+
+      Bit 0    (Most significant bit) When set indicates presence of
+               Hop_Lim and node_id in the node data.
+
+      Bit 1    When set indicates presence of ingress_if_id and
+               egress_if_id (short format) in the node data.
+
+      Bit 2    When set indicates presence of timestamp seconds in the
+               node data.
+
+      Bit 3    When set indicates presence of timestamp subseconds in
+               the node data.
+
+      Bit 4    When set indicates presence of transit delay in the node
+               data.
+
+      Bit 5    When set indicates presence of IOAM-Namespace specific
+               data (short format) in the node data.
+
+      Bit 6    When set indicates presence of queue depth in the node
+               data.
+
+      Bit 7    When set indicates presence of the Checksum Complement
+               node data.
+
+      Bit 8    When set indicates presence of Hop_Lim and node_id in
+               wide format in the node data.
+
+      Bit 9    When set indicates presence of ingress_if_id and
+               egress_if_id in wide format in the node data.
+
+      Bit 10   When set indicates presence of IOAM-Namespace specific
+               data in wide format in the node data.
+
+      Bit 11   When set indicates presence of buffer occupancy in the
+               node data.
+
+      Bit 12-21  Undefined.  An IOAM encapsulating node MUST set the
+               value of each of these bits to 0.  If an IOAM transit
+               node receives a packet with one or more of these bits set
+               to 1, it must either:
+
+               1.  Add corresponding node data filled with the reserved
+                   value 0xFFFFFFFF, after the node data fields for the
+                   IOAM-Trace-Type bits defined above, such that the
+
+
+
+
+Brockners, et al.         Expires March 6, 2020                [Page 14]
+
+Internet-Draft           In-situ OAM Data Fields          September 2019
+
+
+                   total node data added by this node in units of
+                   4-octets is equal to NodeLen, or
+
+               2.  Not add any node data fields to the packet, even for
+                   the IOAM-Trace-Type bits defined above.
+
+      Bit 22   When set indicates presence of variable length Opaque
+               State Snapshot field.
+
+      Bit 23   Reserved: Must be set to zero upon transmission and
+               ignored upon receipt.
+
+      Section 4.4.2 describes the IOAM-Data-Types and their formats.
+      Within an IOAM-Domain possible combinations of these bits making
+      the IOAM-Trace-Type can be restricted by configuration knobs.
+
+   Reserved:  8-bits.  Must be zero.
+
+   Node data List [n]:  Variable-length field.  The type of which is
+      determined by the IOAM-Trace-Type bit representing the n-th node
+      data in the node data list.  The node data list is encoded
+      starting from the last node data of the path.  The first element
+      of the node data list (node data list [0]) contains the last node
+      of the path while the last node data of the node data list (node
+      data list[n]) contains the first node data of the path traced.
+      Populating the node data list in this way ensures that the order
+      of node data list is the same for incremental and pre-allocated
+      trace options.  In the pre-allocated trace option, the index
+      contained in RemainingLen identifies the offset for current active
+      node data to be populated.
+
+4.4.2.  IOAM node data fields and associated formats
+
+   All the IOAM-Data-Fields MUST be 4-octet aligned.  If a node which is
+   supposed to update an IOAM-Data-Field is not capable of populating
+   the value of a field set in the IOAM-Trace-Type, the field value MUST
+   be set to 0xFFFFFFFF for 4-octet fields or 0xFFFFFFFFFFFFFFFF for
+   8-octet fields, indicating that the value is not populated, except
+   when explicitly specified in the field description below.
+
+   Some IOAM-Data-Fields defined below, such as interface identifiers or
+   IOAM-Namespace specific data, are defined in both "short format" as
+   well as "wide format".  Their use is not exclusive.  A deployment
+   could choose to leverage both.  For example, ingress_if_id_(short
+   format) could be an identifier for the physical interface, whereas
+   ingress_if_id_(wide format) could be an identifier for a logical sub-
+   interface of that physical interface.
+
+
+
+
+Brockners, et al.         Expires March 6, 2020                [Page 15]
+
+Internet-Draft           In-situ OAM Data Fields          September 2019
+
+
+   Data field and associated data type for each of the IOAM-Data-Fields
+   is shown below:
+
+   Hop_Lim and node_id:  4-octet field defined as follows:
+
+    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |   Hop_Lim     |              node_id                          |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+      Hop_Lim:  1-octet unsigned integer.  It is set to the Hop Limit
+         value in the packet at the node that records this data.  Hop
+         Limit information is used to identify the location of the node
+         in the communication path.  This is copied from the lower
+         layer, e.g., TTL value in IPv4 header or hop limit field from
+         IPv6 header of the packet when the packet is ready for
+         transmission.  The semantics of the Hop_Lim field depend on the
+         lower layer protocol that IOAM is encapsulated over, and
+         therefore its specific semantics are outside the scope of this
+         memo.
+
+      node_id:  3-octet unsigned integer.  Node identifier field to
+         uniquely identify a node within the IOAM-Namespace and
+         associated IOAM-Domain.  The procedure to allocate, manage and
+         map the node_ids is beyond the scope of this document.
+
+   ingress_if_id and egress_if_id:  4-octet field defined as follows:
+
+    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |     ingress_if_id             |         egress_if_id          |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+      ingress_if_id:  2-octet unsigned integer.  Interface identifier to
+         record the ingress interface the packet was received on.
+
+      egress_if_id:  2-octet unsigned integer.  Interface identifier to
+         record the egress interface the packet is forwarded out of.
+
+      Note that due to the fact that IOAM uses its own IOAM-Namespaces
+      for IOAM-Data-Fields, data fields like interface identifiers can
+      be used in a flexible way to represent system resources that are
+      associated with ingressing or egressing packets, i.e.
+      ingress_if_id could represent a physical interface, a virtual or
+      logical interface, or even a queue.
+
+   timestamp seconds:  4-octet unsigned integer.  Absolute timestamp in
+      seconds that specifies the time at which the packet was received
+
+
+
+Brockners, et al.         Expires March 6, 2020                [Page 16]
+
+Internet-Draft           In-situ OAM Data Fields          September 2019
+
+
+      by the node.  This field has three possible formats; based on
+      either PTP [IEEE1588v2], NTP [RFC5905], or POSIX [POSIX].  The
+      three timestamp formats are specified in Section 5.  In all three
+      cases, the Timestamp Seconds field contains the 32 most
+      significant bits of the timestamp format that is specified in
+      Section 5.  If a node is not capable of populating this field, it
+      assigns the value 0xFFFFFFFF.  Note that this is a legitimate
+      value that is valid for 1 second in approximately 136 years; the
+      analyzer should correlate several packets or compare the timestamp
+      value to its own time-of-day in order to detect the error
+      indication.
+
+   timestamp subseconds:  4-octet unsigned integer.  Absolute timestamp
+      in subseconds that specifies the time at which the packet was
+      received by the node.  This field has three possible formats;
+      based on either PTP [IEEE1588v2], NTP [RFC5905], or POSIX [POSIX].
+      The three timestamp formats are specified in Section 5.  In all
+      three cases, the Timestamp Subseconds field contains the 32 least
+      significant bits of the timestamp format that is specified in
+      Section 5.  If a node is not capable of populating this field, it
+      assigns the value 0xFFFFFFFF.  Note that this is a legitimate
+      value in the NTP format, valid for approximately 233 picoseconds
+      in every second.  If the NTP format is used the analyzer should
+      correlate several packets in order to detect the error indication.
+
+   transit delay:  4-octet unsigned integer in the range 0 to 2^31-1.
+      It is the time in nanoseconds the packet spent in the transit
+      node.  This can serve as an indication of the queuing delay at the
+      node.  If the transit delay exceeds 2^31-1 nanoseconds then the
+      top bit 'O' is set to indicate overflow and value set to
+      0x80000000.  When this field is part of the data field but a node
+      populating the field is not able to fill it, the field position in
+      the field must be filled with value 0xFFFFFFFF to mean not
+      populated.
+
+    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |O|                     transit delay                           |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+   namespace specific data:  4-octet field which can be used by the node
+      to add IOAM-Namespace specific data.  This represents a "free-
+      format" 4-octet bit field with its semantics defined in the
+      context of a specific IOAM-Namespace.
+
+
+
+
+
+
+
+Brockners, et al.         Expires March 6, 2020                [Page 17]
+
+Internet-Draft           In-situ OAM Data Fields          September 2019
+
+
+    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |                    namespace specific data                    |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+   queue depth:  4-octet unsigned integer field.  This field indicates
+      the current length of the egress interface queue of the interface
+      from where the packet is forwarded out.  The queue depth is
+      expressed as the current number of memory buffers used by the
+      queue (a packet may consume one or more memory buffers, depending
+      on its size).
+
+    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |                       queue depth                             |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+   Hop_Lim and node_id wide:  8-octet field defined as follows:
+
+    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |   Hop_Lim     |              node_id                          ~
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   ~                         node_id (contd)                       |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+      Hop_Lim:  1-octet unsigned integer.  It is set to the Hop Limit
+         value in the packet at the node that records this data.  Hop
+         Limit information is used to identify the location of the node
+         in the communication path.  This is copied from the lower layer
+         for e.g.  TTL value in IPv4 header or hop limit field from IPv6
+         header of the packet.  The semantics of the Hop_Lim field
+         depend on the lower layer protocol that IOAM is encapsulated
+         over, and therefore its specific semantics are outside the
+         scope of this memo.
+
+      node_id:  7-octet unsigned integer.  Node identifier field to
+         uniquely identify a node within the IOAM-Namespace and
+         associated IOAM-Domain.  The procedure to allocate, manage and
+         map the node_ids is beyond the scope of this document.
+
+   ingress_if_id and egress_if_id wide:  8-octet field defined as
+      follows:
+
+
+
+
+
+
+
+
+Brockners, et al.         Expires March 6, 2020                [Page 18]
+
+Internet-Draft           In-situ OAM Data Fields          September 2019
+
+
+    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |                       ingress_if_id                           |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |                       egress_if_id                            |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+      ingress_if_id:  4-octet unsigned integer.  Interface identifier to
+         record the ingress interface the packet was received on.
+
+      egress_if_id:  4-octet unsigned integer.  Interface identifier to
+         record the egress interface the packet is forwarded out of.
+
+   namespace specific data wide:  8-octet field which can be used by the
+      node to add IOAM-Namespace specific data.  This represents a
+      "free-format" 8-octet bit field with its semantics defined in the
+      context of a specific IOAM-Namespace.
+
+    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |                    namespace specific data                    ~
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   ~                namespace specific data (contd)                |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+   buffer occupancy:  4-octet unsigned integer field.  This field
+      indicates the current status of the occupancy of the common buffer
+      pool used by a set of queues.  The units of this field depend on
+      the equipment type and deployment and has to be interpreted within
+      the context of an IOAM-Namespace and/or node-id if used.
+
+    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |                       buffer occupancy                        |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+   Checksum Complement:  4-octet node data which contains a 4-octet
+      Checksum Complement field.  The Checksum Complement is useful when
+      IOAM is transported over encapsulations that make use of a UDP
+      transport, such as VXLAN-GPE or Geneve.  Without the Checksum
+      Complement, nodes adding IOAM node data must update the UDP
+      Checksum field.  When the Checksum Complement is present, an IOAM
+      encapsulating node or IOAM transit node adding node data MUST
+      carry out one of the following two alternatives in order to
+      maintain the correctness of the UDP Checksum value:
+
+      1.  Recompute the UDP Checksum field.
+
+
+
+
+Brockners, et al.         Expires March 6, 2020                [Page 19]
+
+Internet-Draft           In-situ OAM Data Fields          September 2019
+
+
+      2.  Use the Checksum Complement to make a checksum-neutral update
+          in the UDP payload; the Checksum Complement is assigned a
+          value that complements the rest of the node data fields that
+          were added by the current node, causing the existing UDP
+          Checksum field to remain correct.
+
+      IOAM decapsulating nodes MUST recompute the UDP Checksum field,
+      since they do not know whether previous hops modified the UDP
+      Checksum field or the Checksum Complement field.
+
+      Checksum Complement fields are used in a similar manner in
+      [RFC7820] and [RFC7821].
+
+    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |                   Checksum Complement                         |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+   Opaque State Snapshot:  Opaque State Snapshot is a variable length
+      field and immediately follows the fixed length IOAM-Data-Fields
+      defined above.  It allows the network element to store an
+      arbitrary state in the node data field, without a pre-defined
+      schema.  The schema is to be defined within the context of an
+      IOAM-Namespace.  The schema needs to be made known to the analyzer
+      by some out-of-band mechanism.  The specification of this
+      mechanism is beyond the scope of this document.  A 24-bit "Schema
+      Id" field, interpreted within the context of an IOAM-Namespace,
+      indicates which particular schema is used, and should be
+      configured on the network element by the operator.
+
+       0                   1                   2                   3
+       0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |   Length      |                     Schema ID                 |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |                                                               |
+      |                                                               |
+      |                        Opaque data                            |
+      ~                                                               ~
+      .                                                               .
+      .                                                               .
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+      Length:  1-octet unsigned integer.  It is the length in multiples
+         of 4-octets of the Opaque data field that follows Schema Id.
+
+      Schema ID:  3-octet unsigned integer identifying the schema of
+         Opaque data.
+
+
+
+Brockners, et al.         Expires March 6, 2020                [Page 20]
+
+Internet-Draft           In-situ OAM Data Fields          September 2019
+
+
+      Opaque data:  Variable length field.  This field is interpreted as
+         specified by the schema identified by the Schema ID.
+
+      When this field is part of the data field but a node populating
+      the field has no opaque state data to report, the Length must be
+      set to 0 and the Schema ID must be set to 0xFFFFFF to mean no
+      schema.
+
+4.4.3.  Examples of IOAM node data
+
+   An entry in the "node data list" array can have different formats,
+   following the needs of the deployment.  Some deployments might only
+   be interested in recording the node identifiers, whereas others might
+   be interested in recording node identifier and timestamp.  The
+   section provides example entries of the "node data list".
+
+   0xD40000:  IOAM-Trace-Type is 0xD40000 (0b110101000000000000000000)
+      then the format of node data is:
+
+        0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |   Hop_Lim     |              node_id                          |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |     ingress_if_id             |         egress_if_id          |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |                     timestamp subseconds                      |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |                    namespace specific data                    |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+
+
+   0xC00000:  IOAM-Trace-Type is 0xC00000 (0b110000000000000000000000)
+      then the format is:
+
+        0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |   Hop_Lim     |              node_id                          |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |     ingress_if_id             |         egress_if_id          |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+
+   0x900000:  IOAM-Trace-Type is 0x900000 (0b100100000000000000000000)
+      then the format is:
+
+
+
+
+
+
+Brockners, et al.         Expires March 6, 2020                [Page 21]
+
+Internet-Draft           In-situ OAM Data Fields          September 2019
+
+
+        0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |   Hop_Lim     |              node_id                          |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |                   timestamp subseconds                        |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+
+   0x840000:  IOAM-Trace-Type is 0x840000 (0b100001000000000000000000)
+      then the format is:
+
+        0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |   Hop_Lim     |              node_id                          |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |                    namespace specific data                    |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+
+   0x940000:  IOAM-Trace-Type is 0x940000 (0b100101000000000000000000)
+      then the format is:
+
+        0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |   Hop_Lim     |              node_id                          |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |                    timestamp subseconds                       |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |                    namespace specific data                    |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+
+   0x308002:  IOAM-Trace-Type is 0x308002 (0b001100001000000000000010)
+      then the format is:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Brockners, et al.         Expires March 6, 2020                [Page 22]
+
+Internet-Draft           In-situ OAM Data Fields          September 2019
+
+
+        0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |                      timestamp seconds                        |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |                    timestamp subseconds                       |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |   Hop_Lim     |              node_id                          |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |                         node_id(contd)                        |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |   Length      |                     Schema Id                 |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |                                                               |
+       |                                                               |
+       |                        Opaque data                            |
+       ~                                                               ~
+       .                                                               .
+       .                                                               .
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+
+4.5.  IOAM Proof of Transit Option-Type
+
+   IOAM Proof of Transit Option-Type is to support path or service
+   function chain [RFC7665] verification use cases.  Proof-of-transit
+   uses methods like nested hashing or nested encryption of the IOAM
+   data or mechanisms such as Shamir's Secret Sharing Schema (SSSS).
+   While details on how the IOAM data for the proof of transit option is
+   processed at IOAM encapsulating, decapsulating and transit nodes are
+   outside the scope of the document, all of these approaches share the
+   need to uniquely identify a packet as well as iteratively operate on
+   a set of information that is handed from node to node.
+   Correspondingly, two pieces of information are added as IOAM-Data-
+   Fields to the packet:
+
+   o  Random: Unique identifier for the packet (e.g., 64-bits allow for
+      the unique identification of 2^64 packets).
+
+   o  Cumulative: Information which is handed from node to node and
+      updated by every node according to a verification algorithm.
+
+   The IOAM Proof of Transit Option-Type consist of a fixed size "IOAM
+   proof of transit option header" and "IOAM proof of transit option
+   data fields":
+
+
+
+
+
+
+
+Brockners, et al.         Expires March 6, 2020                [Page 23]
+
+Internet-Draft           In-situ OAM Data Fields          September 2019
+
+
+   IOAM proof of transit option header:
+
+    0                   1                   2                   3
+    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |       Namespace-ID            |IOAM POT Type  | IOAM POT flags|
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+   IOAM proof of transit Option-Type IOAM-Data-Fields MUST be
+   4-octet aligned:
+
+    0                   1                   2                   3
+    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |       POT Option data field determined by IOAM-POT-Type       |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+
+
+   Namespace-ID:  16-bit identifier of an IOAM-Namespace.  The
+      Namespace-ID value of 0x0000 is defined as the default value and
+      MUST be known to all the nodes implementing IOAM.  For any other
+      Namespace-ID value that does not match any Namespace-ID the node
+      is configured to operate on, the node MUST NOT change the contents
+      of the IOAM-Data-Fields.
+
+   IOAM POT Type:  8-bit identifier of a particular POT variant that
+      specifies the POT data that is included.  This document defines
+      POT Type 0:
+
+      0: POT data is a 16 Octet field as described below.
+
+   IOAM POT flags:  8-bit.  Following flags are defined:
+
+      Bit 0  "Profile-to-use" (P-bit) (most significant bit).  For IOAM
+         POT types that use a maximum of two profiles to drive
+         computation, indicates which POT-profile is used.  The two
+         profiles are numbered 0, 1.
+
+      Bit 1-7  Reserved: Must be set to zero upon transmission and
+         ignored upon receipt.
+
+   POT Option data:  Variable-length field.  The type of which is
+      determined by the IOAM-POT-Type.
+
+
+
+
+
+
+
+Brockners, et al.         Expires March 6, 2020                [Page 24]
+
+Internet-Draft           In-situ OAM Data Fields          September 2019
+
+
+4.5.1.  IOAM Proof of Transit Type 0
+
+   IOAM proof of transit option of IOAM POT Type 0:
+
+    0                   1                   2                   3
+    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |        Namespace-ID           |IOAM POT Type=0|P|R R R R R R R|
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+<-+
+   |                        Random                                 |  |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+  P
+   |                        Random(contd)                          |  O
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+  T
+   |                        Cumulative                             |  |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+  |
+   |                        Cumulative (contd)                     |  |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+<-+
+
+
+
+   Namespace-ID:  16-bit identifier of an IOAM-Namespace.  The
+      Namespace-ID value of 0x0000 is defined as the default value and
+      MUST be known to all the nodes implementing IOAM.  For any other
+      Namespace-ID value that does not match any Namespace-ID the node
+      is configured to operate on, the node MUST NOT change the contents
+      of the IOAM-Data-Fields.
+
+   IOAM POT Type:  8-bit identifier of a particular POT variant that
+      specifies the POT data that is included.  This section defines the
+      POT data when the IOAM POT Type is set to the value 0.
+
+   P bit:  1-bit.  "Profile-to-use" (P-bit) (most significant bit).
+      Indicates which POT-profile is used to generate the Cumulative.
+      Any node participating in POT will have a maximum of 2 profiles
+      configured that drive the computation of cumulative.  The two
+      profiles are numbered 0, 1.  This bit conveys whether profile 0 or
+      profile 1 is used to compute the Cumulative.
+
+   R (7 bits):  7-bit IOAM POT flags for future use.  MUST be set to
+      zero upon transmission and ignored upon receipt.
+
+   Random:  64-bit Per packet Random number.
+
+   Cumulative:  64-bit Cumulative that is updated at specific nodes by
+      processing per packet Random number field and configured
+      parameters.
+
+
+
+
+
+Brockners, et al.         Expires March 6, 2020                [Page 25]
+
+Internet-Draft           In-situ OAM Data Fields          September 2019
+
+
+   Note: Larger or smaller sizes of "Random" and "Cumulative" data are
+   feasible and could be required for certain deployments (e.g. in case
+   of space constraints in the transport protocol used).  Future
+   versions of this document will address different sizes of data for
+   "proof of transit".
+
+4.6.  IOAM Edge-to-Edge Option-Type
+
+   The IOAM Edge-to-Edge Option-Type is to carry data that is added by
+   the IOAM encapsulating node and interpreted by IOAM decapsulating
+   node.  The IOAM transit nodes MAY process the data but MUST NOT
+   modify it.
+
+   The IOAM Edge-to-Edge Option-Type consist of a fixed size "IOAM Edge-
+   to-Edge Option-Type header" and "IOAM Edge-to-Edge Option-Type data
+   fields":
+
+   IOAM Edge-to-Edge Option-Type header:
+
+    0                   1                   2                   3
+    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |        Namespace-ID           |         IOAM-E2E-Type         |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+   IOAM Edge-to-Edge Option-Type IOAM-Data-Fields MUST
+   be 4-octet aligned:
+
+    0                   1                   2                   3
+    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |       E2E Option data field determined by IOAM-E2E-Type       |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+
+   Namespace-ID:  16-bit identifier of an IOAM-Namespace.  The
+      Namespace-ID value of 0x0000 is defined as the default value and
+      MUST be known to all the nodes implementing IOAM.  For any other
+      Namespace-ID value that does not match any Namespace-ID the node
+      is configured to operate on, then the node MUST NOT change the
+      contents of the IOAM-Data-Fields.
+
+   IOAM-E2E-Type:  A 16-bit identifier which specifies which data types
+      are used in the E2E option data.  The IOAM-E2E-Type value is a bit
+      field.  The order of packing the E2E option data field elements
+      follows the bit order of the IOAM-E2E-Type field, as follows:
+
+
+
+
+
+Brockners, et al.         Expires March 6, 2020                [Page 26]
+
+Internet-Draft           In-situ OAM Data Fields          September 2019
+
+
+      Bit 0    (Most significant bit) When set indicates presence of a
+               64-bit sequence number added to a specific "packet group"
+               which is used to detect packet loss, packet reordering,
+               or packet duplication within the group.  The "packet
+               group" is deployment dependent and defined at the IOAM
+               encapsulating node e.g. by n-tuple based classification
+               of packets.
+
+      Bit 1    When set indicates presence of a 32-bit sequence number
+               added to a specific "packet group" which is used to
+               detect packet loss, packet reordering, or packet
+               duplication within that group.  The "packet group" is
+               deployment dependent and defined at the IOAM
+               encapsulating node e.g. by n-tuple based classification
+               of packets.
+
+      Bit 2    When set indicates presence of timestamp seconds for the
+               transmission of the frame.  This 4-octet field has three
+               possible formats; based on either PTP [IEEE1588v2], NTP
+               [RFC5905], or POSIX [POSIX].  The three timestamp formats
+               are specified in Section 5.  In all three cases, the
+               Timestamp Seconds field contains the 32 most significant
+               bits of the timestamp format that is specified in
+               Section 5.  If a node is not capable of populating this
+               field, it assigns the value 0xFFFFFFFF.  Note that this
+               is a legitimate value that is valid for 1 second in
+               approximately 136 years; the analyzer should correlate
+               several packets or compare the timestamp value to its own
+               time-of-day in order to detect the error indication.
+
+      Bit 3    When set indicates presence of timestamp subseconds for
+               the transmission of the frame.  This 4-octet field has
+               three possible formats; based on either PTP [IEEE1588v2],
+               NTP [RFC5905], or POSIX [POSIX].  The three timestamp
+               formats are specified in Section 5.  In all three cases,
+               the Timestamp Subseconds field contains the 32 least
+               significant bits of the timestamp format that is
+               specified in Section 5.  If a node is not capable of
+               populating this field, it assigns the value 0xFFFFFFFF.
+               Note that this is a legitimate value in the NTP format,
+               valid for approximately 233 picoseconds in every second.
+               If the NTP format is used the analyzer should correlate
+               several packets in order to detect the error indication.
+
+      Bit 4-15 Undefined.  An IOAM encapsulating node Must set the value
+               of these bits to zero upon transmission and ignore upon
+               receipt.
+
+
+
+
+Brockners, et al.         Expires March 6, 2020                [Page 27]
+
+Internet-Draft           In-situ OAM Data Fields          September 2019
+
+
+   E2E Option data:  Variable-length field.  The type of which is
+      determined by the IOAM-E2E-Type.
+
+5.  Timestamp Formats
+
+   The IOAM-Data-Fields include a timestamp field which is represented
+   in one of three possible timestamp formats.  It is assumed that the
+   management plane is responsible for determining which timestamp
+   format is used.
+
+5.1.  PTP Truncated Timestamp Format
+
+   The Precision Time Protocol (PTP) [IEEE1588v2] uses an 80-bit
+   timestamp format.  The truncated timestamp format is a 64-bit field,
+   which is the 64 least significant bits of the 80-bit PTP timestamp.
+   The PTP truncated format is specified in Section 4.3 of
+   [I-D.ietf-ntp-packet-timestamps], and the details are presented below
+   for the sake of completeness.
+
+
+        0                   1                   2                   3
+        0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |                            Seconds                            |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |                          Nanoseconds                          |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+           Figure 1: PTP [IEEE1588v2] Truncated Timestamp Format
+
+   Timestamp field format:
+
+      Seconds: specifies the integer portion of the number of seconds
+      since the epoch.
+
+      + Size: 32 bits.
+
+      + Units: seconds.
+
+      Nanoseconds: specifies the fractional portion of the number of
+      seconds since the epoch.
+
+      + Size: 32 bits.
+
+      + Units: nanoseconds.  The value of this field is in the range 0
+      to (10^9)-1.
+
+   Epoch:
+
+
+
+Brockners, et al.         Expires March 6, 2020                [Page 28]
+
+Internet-Draft           In-situ OAM Data Fields          September 2019
+
+
+      The PTP [IEEE1588v2] epoch is 1 January 1970 00:00:00 TAI, which
+      is 31 December 1969 23:59:51.999918 UTC.
+
+   Resolution:
+
+      The resolution is 1 nanosecond.
+
+   Wraparound:
+
+      This time format wraps around every 2^32 seconds, which is roughly
+      136 years.  The next wraparound will occur in the year 2106.
+
+   Synchronization Aspects:
+
+      It is assumed that nodes that run this protocol are synchronized
+      among themselves.  Nodes may be synchronized to a global reference
+      time.  Note that if PTP [IEEE1588v2] is used for synchronization,
+      the timestamp may be derived from the PTP-synchronized clock,
+      allowing the timestamp to be measured with respect to the clock of
+      an PTP Grandmaster clock.
+
+      The PTP truncated timestamp format is not affected by leap
+      seconds.
+
+5.2.  NTP 64-bit Timestamp Format
+
+   The Network Time Protocol (NTP) [RFC5905] timestamp format is 64 bits
+   long.  This format is specified in Section 4.2.1 of
+   [I-D.ietf-ntp-packet-timestamps], and the details are presented below
+   for the sake of completeness.
+
+
+        0                   1                   2                   3
+        0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |                            Seconds                            |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |                            Fraction                           |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+              Figure 2: NTP [RFC5905] 64-bit Timestamp Format
+
+   Timestamp field format:
+
+      Seconds: specifies the integer portion of the number of seconds
+      since the epoch.
+
+      + Size: 32 bits.
+
+
+
+Brockners, et al.         Expires March 6, 2020                [Page 29]
+
+Internet-Draft           In-situ OAM Data Fields          September 2019
+
+
+      + Units: seconds.
+
+      Fraction: specifies the fractional portion of the number of
+      seconds since the epoch.
+
+      + Size: 32 bits.
+
+      + Units: the unit is 2^(-32) seconds, which is roughly equal to
+      233 picoseconds.
+
+   Epoch:
+
+      The epoch is 1 January 1900 at 00:00 UTC.
+
+   Resolution:
+
+      The resolution is 2^(-32) seconds.
+
+   Wraparound:
+
+      This time format wraps around every 2^32 seconds, which is roughly
+      136 years.  The next wraparound will occur in the year 2036.
+
+   Synchronization Aspects:
+
+      Nodes that use this timestamp format will typically be
+      synchronized to UTC using NTP [RFC5905].  Thus, the timestamp may
+      be derived from the NTP-synchronized clock, allowing the timestamp
+      to be measured with respect to the clock of an NTP server.
+
+      The NTP timestamp format is affected by leap seconds; it
+      represents the number of seconds since the epoch minus the number
+      of leap seconds that have occurred since the epoch.  The value of
+      a timestamp during or slightly after a leap second may be
+      temporarily inaccurate.
+
+5.3.  POSIX-based Timestamp Format
+
+   This timestamp format is based on the POSIX time format [POSIX].  The
+   detailed specification of the timestamp format used in this document
+   is presented below.
+
+
+
+
+
+
+
+
+
+
+Brockners, et al.         Expires March 6, 2020                [Page 30]
+
+Internet-Draft           In-situ OAM Data Fields          September 2019
+
+
+        0                   1                   2                   3
+        0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |                            Seconds                            |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |                          Microseconds                         |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+                  Figure 3: POSIX-based Timestamp Format
+
+   Timestamp field format:
+
+      Seconds: specifies the integer portion of the number of seconds
+      since the epoch.
+
+      + Size: 32 bits.
+
+      + Units: seconds.
+
+      Microseconds: specifies the fractional portion of the number of
+      seconds since the epoch.
+
+      + Size: 32 bits.
+
+      + Units: the unit is microseconds.  The value of this field is in
+      the range 0 to (10^6)-1.
+
+   Epoch:
+
+      The epoch is 1 January 1970 00:00:00 TAI, which is 31 December
+      1969 23:59:51.999918 UTC.
+
+   Resolution:
+
+      The resolution is 1 microsecond.
+
+   Wraparound:
+
+      This time format wraps around every 2^32 seconds, which is roughly
+      136 years.  The next wraparound will occur in the year 2106.
+
+   Synchronization Aspects:
+
+      It is assumed that nodes that use this timestamp format run Linux
+      operating system, and hence use the POSIX time.  In some cases
+      nodes may be synchronized to UTC using a synchronization mechanism
+      that is outside the scope of this document, such as NTP [RFC5905].
+      Thus, the timestamp may be derived from the NTP-synchronized
+
+
+
+Brockners, et al.         Expires March 6, 2020                [Page 31]
+
+Internet-Draft           In-situ OAM Data Fields          September 2019
+
+
+      clock, allowing the timestamp to be measured with respect to the
+      clock of an NTP server.
+
+      The POSIX-based timestamp format is affected by leap seconds; it
+      represents the number of seconds since the epoch minus the number
+      of leap seconds that have occurred since the epoch.  The value of
+      a timestamp during or slightly after a leap second may be
+      temporarily inaccurate.
+
+6.  IOAM Data Export
+
+   IOAM nodes collect information for packets traversing a domain that
+   supports IOAM.  IOAM decapsulating nodes as well as IOAM transit
+   nodes can choose to retrieve IOAM information from the packet,
+   process the information further and export the information using
+   e.g., IPFIX.  The mechanisms and associated data formats for
+   exporting IOAM data is outside the scope of this document.
+
+   Raw data export of IOAM data using IPFIX is discussed in
+   [I-D.spiegel-ippm-ioam-rawexport].
+
+7.  IANA Considerations
+
+   This document requests the following IANA Actions.
+
+7.1.  Creation of a new In-Situ OAM Protocol Parameters Registry (IOAM)
+      Protocol Parameters IANA registry
+
+   IANA is requested to create a new protocol registry for "In-Situ OAM
+   (IOAM) Protocol Parameters".  This is the common registry that will
+   include registrations for all IOAM-Namespaces.  Each Registry, whose
+   names are listed below:
+
+      IOAM Option-Type
+
+      IOAM Trace-Type
+
+      IOAM Trace-Flags
+
+      IOAM POT-Type
+
+      IOAM POT-Flags
+
+      IOAM E2E-Type
+
+      IOAM Namespace-ID
+
+
+
+
+
+Brockners, et al.         Expires March 6, 2020                [Page 32]
+
+Internet-Draft           In-situ OAM Data Fields          September 2019
+
+
+   will contain the current set of possibilities defined in this
+   document.  New registries in this name space are created via RFC
+   Required process as per [RFC8126].
+
+   The subsequent sub-sections detail the registries herein contained.
+
+7.2.  IOAM Option-Type Registry
+
+   This registry defines 128 code points for the IOAM Option-Type field
+   for identifying IOAM Option-Types as explained in Section 4.  The
+   following code points are defined in this draft:
+
+   0  IOAM Pre-allocated Trace Option-Type
+
+   1  IOAM Incremental Trace Option-Type
+
+   2  IOAM POT Option-Type
+
+   3  IOAM E2E Option-Type
+
+   4 - 127 are available for assignment via RFC Required process as per
+   [RFC8126].
+
+7.3.  IOAM Trace-Type Registry
+
+   This registry defines code point for each bit in the 24-bit IOAM-
+   Trace-Type field for Pre-allocated trace option and Incremental trace
+   option defined in Section 4.4.  The meaning of Bits 0 - 11 for trace
+   type are defined in this document in Paragraph 5 of Section 4.4.1:
+
+   Bit 0  hop_Lim and node_id in short format
+
+   Bit 1  ingress_if_id and egress_if_id in short format
+
+   Bit 2  timestamp seconds
+
+   Bit 3  timestamp subseconds
+
+   Bit 4  transit delay
+
+   Bit 5  namespace specific data in short format
+
+   Bit 6  queue depth
+
+   Bit 7  checksum complement
+
+   Bit 8  hop_Lim and node_id in wide format
+
+
+
+
+Brockners, et al.         Expires March 6, 2020                [Page 33]
+
+Internet-Draft           In-situ OAM Data Fields          September 2019
+
+
+   Bit 9  ingress_if_id and egress_if_id in wide format
+
+   Bit 10  namespace specific data in wide format
+
+   Bit 11  buffer occupancy
+
+   Bit 22  variable length Opaque State Snapshot
+
+   Bit 23  reserved
+
+   The meaning for Bits 12 - 21 are available for assignment via RFC
+   Required process as per [RFC8126].
+
+7.4.  IOAM Trace-Flags Registry
+
+   This registry defines code points for each bit in the 4 bit flags for
+   the Pre-allocated trace option and for the Incremental trace option
+   defined in Section 4.4.  The meaning of Bit 0 (the most significant
+   bit) for trace flags is defined in this document in Paragraph 3 of
+   Section 4.4.1:
+
+   Bit 0  "Overflow" (O-bit)
+
+7.5.  IOAM POT-Type Registry
+
+   This registry defines 256 code points to define IOAM POT Type for
+   IOAM proof of transit option Section 4.5.  The code point value 0 is
+   defined in this document:
+
+   0: 16 Octet POT data
+
+   1 - 255 are available for assignment via RFC Required process as per
+   [RFC8126].
+
+7.6.  IOAM POT-Flags Registry
+
+   This registry defines code points for each bit in the 8 bit flags for
+   IOAM POT option defined in Section 4.5.  The meaning of Bit 0 for
+   IOAM POT flags is defined in this document in Section 4.5:
+
+   Bit 0  "Profile-to-use" (P-bit)
+
+   The meaning for Bits 1 - 7 are available for assignment via RFC
+   Required process as per [RFC8126].
+
+
+
+
+
+
+
+Brockners, et al.         Expires March 6, 2020                [Page 34]
+
+Internet-Draft           In-situ OAM Data Fields          September 2019
+
+
+7.7.  IOAM E2E-Type Registry
+
+   This registry defines code points for each bit in the 16 bit IOAM-
+   E2E-Type field for IOAM E2E option Section 4.6.  The meaning of Bit 0
+   - 3 are defined in this document:
+
+   Bit 0  64-bit sequence number
+
+   Bit 1  32-bit sequence number
+
+   Bit 2  timestamp seconds
+
+   Bit 3  timestamp subseconds
+
+   The meaning of Bits 4 - 15 are available for assignment via RFC
+   Required process as per [RFC8126].
+
+7.8.  IOAM Namespace-ID Registry
+
+   IANA is requested to set up an "IOAM Namespace-ID Registry",
+   containing 16-bit values.  The meaning of Bit 0 is defined in this
+   document.  IANA is requested to reserve the values 0x0001 to 0x7FFF
+   for private use (managed by operators), as specified in Section 4.3
+   of the current document.  Registry entries for the values 0x8000 to
+   0xFFFF are to be assigned via the "Expert Review" policy defined in
+   [RFC8126].
+
+   0: default namespace (known to all IOAM nodes)
+
+   0x0001 - 0x7FFF:  reserved for private use
+
+   0x8000 - 0xFFFF:  unassigned
+
+8.  Security Considerations
+
+   As discussed in [RFC7276], a successful attack on an OAM protocol in
+   general, and specifically on IOAM, can prevent the detection of
+   failures or anomalies, or create a false illusion of nonexistent
+   ones.
+
+   The Proof of Transit Option-Type (Section Section 4.5) is used for
+   verifying the path of data packets.  The security considerations of
+   POT are further discussed in [I-D.ietf-sfc-proof-of-transit].
+
+   The data elements of IOAM can be used for network reconnaissance,
+   allowing attackers to collect information about network paths,
+   performance, queue states, buffer occupancy and other information.
+   Note that in case IOAM is used in "immediate export" mode (reference
+
+
+
+Brockners, et al.         Expires March 6, 2020                [Page 35]
+
+Internet-Draft           In-situ OAM Data Fields          September 2019
+
+
+   to be added in a future revision), the IOAM related trace information
+   would not be available in the customer data packets, but would
+   trigger export of packet related IOAM information at every node.
+   IOAM data export and securing IOAM data export is outside the scope
+   of this document.
+
+   IOAM can be used as a means for implementing Denial of Service (DoS)
+   attacks, or for amplifying them.  For example, a malicious attacker
+   can add an IOAM header to packets in order to consume the resources
+   of network devices that take part in IOAM or collectors that analyze
+   the IOAM data.  Another example is a packet length attack, in which
+   an attacker pushes headers associated with IOAM Option-Types into
+   data packets, causing these packets to be increased beyond the MTU
+   size, resulting in fragmentation or in packet drops.
+
+   Since IOAM options may include timestamps, if network devices use
+   synchronization protocols then any attack on the time protocol
+   [RFC7384] can compromise the integrity of the timestamp-related data
+   fields.
+
+   At the management plane, attacks may be implemented by misconfiguring
+   or by maliciously configuring IOAM-enabled nodes in a way that
+   enables other attacks.  Thus, IOAM configuration should be secured in
+   a way that authenticates authorized users and verifies the integrity
+   of configuration procedures.
+
+   Notably, IOAM is expected to be deployed in specific network domains,
+   thus confining the potential attack vectors to within the network
+   domain.  Indeed, in order to limit the scope of threats to within the
+   current network domain the network operator is expected to enforce
+   policies that prevent IOAM traffic from leaking outside of the IOAM
+   domain, and prevent IOAM data from outside the domain to be processed
+   and used within the domain.  Note that the Immediate Export mode
+   (reference to be added in a future revision) can mitigate the
+   potential threat of IOAM data leaking through data packets.
+
+9.  Acknowledgements
+
+   The authors would like to thank Eric Vyncke, Nalini Elkins, Srihari
+   Raghavan, Ranganathan T S, Karthik Babu Harichandra Babu, Akshaya
+   Nadahalli, LJ Wobker, Erik Nordmark, Vengada Prasad Govindan, Andrew
+   Yourtchenko, Aviv Kfir, Tianran Zhou, Haoyu song and Zhenbin (Robin)
+   for the comments and advice.
+
+   This document leverages and builds on top of several concepts
+   described in [I-D.kitamura-ipv6-record-route].  The authors would
+   like to acknowledge the work done by the author Hiroshi Kitamura and
+   people involved in writing it.
+
+
+
+Brockners, et al.         Expires March 6, 2020                [Page 36]
+
+Internet-Draft           In-situ OAM Data Fields          September 2019
+
+
+   The authors would like to gracefully acknowledge useful review and
+   insightful comments received from Joe Clarke, Al Morton, and Mickey
+   Spiegel.
+
+   The authors would like to acknowledge the contribution of "Immediate
+   export" of IOAM trace by Barak Gafni.
+
+10.  References
+
+10.1.  Normative References
+
+   [IEEE1588v2]
+              Institute of Electrical and Electronics Engineers, "IEEE
+              Std 1588-2008 - IEEE Standard for a Precision Clock
+              Synchronization Protocol for Networked Measurement and
+              Control Systems",  IEEE Std 1588-2008, 2008,
+              <http://standards.ieee.org/findstds/
+              standard/1588-2008.html>.
+
+   [POSIX]    Institute of Electrical and Electronics Engineers, "IEEE
+              Std 1003.1-2008 (Revision of IEEE Std 1003.1-2004) - IEEE
+              Standard for Information Technology - Portable Operating
+              System Interface (POSIX(R))",  IEEE Std 1003.1-2008, 2008,
+              <https://standards.ieee.org/findstds/
+              standard/1003.1-2008.html>.
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119,
+              DOI 10.17487/RFC2119, March 1997,
+              <https://www.rfc-editor.org/info/rfc2119>.
+
+   [RFC5905]  Mills, D., Martin, J., Ed., Burbank, J., and W. Kasch,
+              "Network Time Protocol Version 4: Protocol and Algorithms
+              Specification", RFC 5905, DOI 10.17487/RFC5905, June 2010,
+              <https://www.rfc-editor.org/info/rfc5905>.
+
+   [RFC8126]  Cotton, M., Leiba, B., and T. Narten, "Guidelines for
+              Writing an IANA Considerations Section in RFCs", BCP 26,
+              RFC 8126, DOI 10.17487/RFC8126, June 2017,
+              <https://www.rfc-editor.org/info/rfc8126>.
+
+10.2.  Informative References
+
+   [I-D.ietf-ntp-packet-timestamps]
+              Mizrahi, T., Fabini, J., and A. Morton, "Guidelines for
+              Defining Packet Timestamps", draft-ietf-ntp-packet-
+              timestamps-07 (work in progress), August 2019.
+
+
+
+
+Brockners, et al.         Expires March 6, 2020                [Page 37]
+
+Internet-Draft           In-situ OAM Data Fields          September 2019
+
+
+   [I-D.ietf-nvo3-geneve]
+              Gross, J., Ganga, I., and T. Sridhar, "Geneve: Generic
+              Network Virtualization Encapsulation", draft-ietf-
+              nvo3-geneve-13 (work in progress), March 2019.
+
+   [I-D.ietf-nvo3-vxlan-gpe]
+              Maino, F., Kreeger, L., and U. Elzur, "Generic Protocol
+              Extension for VXLAN", draft-ietf-nvo3-vxlan-gpe-07 (work
+              in progress), April 2019.
+
+   [I-D.ietf-sfc-proof-of-transit]
+              Brockners, F., Bhandari, S., Dara, S., Pignataro, C.,
+              Leddy, J., Youell, S., Mozes, D., Mizrahi, T., Aguado, A.,
+              and D. Lopez, "Proof of Transit", draft-ietf-sfc-proof-of-
+              transit-02 (work in progress), March 2019.
+
+   [I-D.kitamura-ipv6-record-route]
+              Kitamura, H., "Record Route for IPv6 (PR6) Hop-by-Hop
+              Option Extension", draft-kitamura-ipv6-record-route-00
+              (work in progress), November 2000.
+
+   [I-D.lapukhov-dataplane-probe]
+              Lapukhov, P. and r. remy@barefootnetworks.com, "Data-plane
+              probe for in-band telemetry collection", draft-lapukhov-
+              dataplane-probe-01 (work in progress), June 2016.
+
+   [I-D.spiegel-ippm-ioam-rawexport]
+              Spiegel, M., Brockners, F., Bhandari, S., and R.
+              Sivakolundu, "In-situ OAM raw data export with IPFIX",
+              draft-spiegel-ippm-ioam-rawexport-02 (work in progress),
+              July 2019.
+
+   [RFC7276]  Mizrahi, T., Sprecher, N., Bellagamba, E., and Y.
+              Weingarten, "An Overview of Operations, Administration,
+              and Maintenance (OAM) Tools", RFC 7276,
+              DOI 10.17487/RFC7276, June 2014,
+              <https://www.rfc-editor.org/info/rfc7276>.
+
+   [RFC7384]  Mizrahi, T., "Security Requirements of Time Protocols in
+              Packet Switched Networks", RFC 7384, DOI 10.17487/RFC7384,
+              October 2014, <https://www.rfc-editor.org/info/rfc7384>.
+
+   [RFC7665]  Halpern, J., Ed. and C. Pignataro, Ed., "Service Function
+              Chaining (SFC) Architecture", RFC 7665,
+              DOI 10.17487/RFC7665, October 2015,
+              <https://www.rfc-editor.org/info/rfc7665>.
+
+
+
+
+
+Brockners, et al.         Expires March 6, 2020                [Page 38]
+
+Internet-Draft           In-situ OAM Data Fields          September 2019
+
+
+   [RFC7799]  Morton, A., "Active and Passive Metrics and Methods (with
+              Hybrid Types In-Between)", RFC 7799, DOI 10.17487/RFC7799,
+              May 2016, <https://www.rfc-editor.org/info/rfc7799>.
+
+   [RFC7820]  Mizrahi, T., "UDP Checksum Complement in the One-Way
+              Active Measurement Protocol (OWAMP) and Two-Way Active
+              Measurement Protocol (TWAMP)", RFC 7820,
+              DOI 10.17487/RFC7820, March 2016,
+              <https://www.rfc-editor.org/info/rfc7820>.
+
+   [RFC7821]  Mizrahi, T., "UDP Checksum Complement in the Network Time
+              Protocol (NTP)", RFC 7821, DOI 10.17487/RFC7821, March
+              2016, <https://www.rfc-editor.org/info/rfc7821>.
+
+   [RFC8300]  Quinn, P., Ed., Elzur, U., Ed., and C. Pignataro, Ed.,
+              "Network Service Header (NSH)", RFC 8300,
+              DOI 10.17487/RFC8300, January 2018,
+              <https://www.rfc-editor.org/info/rfc8300>.
+
+Authors' Addresses
+
+   Frank Brockners
+   Cisco Systems, Inc.
+   Hansaallee 249, 3rd Floor
+   DUESSELDORF, NORDRHEIN-WESTFALEN  40549
+   Germany
+
+   Email: fbrockne@cisco.com
+
+
+   Shwetha Bhandari
+   Cisco Systems, Inc.
+   Cessna Business Park, Sarjapura Marathalli Outer Ring Road
+   Bangalore, KARNATAKA 560 087
+   India
+
+   Email: shwethab@cisco.com
+
+
+   Carlos Pignataro
+   Cisco Systems, Inc.
+   7200-11 Kit Creek Road
+   Research Triangle Park, NC  27709
+   United States
+
+   Email: cpignata@cisco.com
+
+
+
+
+
+Brockners, et al.         Expires March 6, 2020                [Page 39]
+
+Internet-Draft           In-situ OAM Data Fields          September 2019
+
+
+   Hannes Gredler
+   RtBrick Inc.
+
+   Email: hannes@rtbrick.com
+
+
+   John Leddy
+   United States
+
+   Email: john@leddy.net
+
+
+   Stephen Youell
+   JP Morgan Chase
+   25 Bank Street
+   London  E14 5JP
+   United Kingdom
+
+   Email: stephen.youell@jpmorgan.com
+
+
+   Tal Mizrahi
+   Huawei Network.IO Innovation Lab
+   Israel
+
+   Email: tal.mizrahi.phd@gmail.com
+
+
+   David Mozes
+
+   Email: mosesster@gmail.com
+
+
+   Petr Lapukhov
+   Facebook
+   1 Hacker Way
+   Menlo Park, CA  94025
+   US
+
+   Email: petr@fb.com
+
+
+   Remy Chang
+   Barefoot Networks
+   4750 Patrick Henry Drive
+   Santa Clara, CA  95054
+   US
+
+
+
+
+Brockners, et al.         Expires March 6, 2020                [Page 40]
+
+Internet-Draft           In-situ OAM Data Fields          September 2019
+
+
+   Daniel Bernier
+   Bell Canada
+   Canada
+
+   Email: daniel.bernier@bell.ca
+
+
+   John Lemon
+   Broadcom
+   270 Innovation Drive
+   San Jose, CA  95134
+   US
+
+   Email: john.lemon@broadcom.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Brockners, et al.         Expires March 6, 2020                [Page 41]


### PR DESCRIPTION
Update of draft-ietf-ippm-ioam-data-06 to -07 reflecting:
* https://github.com/inband-oam/ietf/issues/132
* https://github.com/inband-oam/ietf/issues/131

Specifically:
* Trace-Type bit 23 changed to "reserved" to allow for future extensions
* Opaque State Snapshot changed to bit 22 (from bit 7) in Trace-Type
* Checksum complement changed to bit 7 (from bit 23) in Trace-Type
* Changed checksum complement to 4 octets
* Added a paragraph in section 4.2.2 that explicitly states that "short" and "wide" fields can be combined and can both be in the same packet.
* IOAM Option-Types is what is used throughout the document now (instead of IOAM Type, IOAM header, IOAM option etc.)
* Explained that pre-allocated and incremental trace options can go hand in hand
* Dedicated subsections in section 4 detailing IOAM nomenclature (aligns better with the fact that there was a dedicated subsection on namespaces)
* Additional editorial clean up