### PR TITLE
Additional Updates for ETH and GENEVE drafts

### DIFF
--- a/drafts/draft-brockners-ippm-ioam-geneve.xml
+++ b/drafts/draft-brockners-ippm-ioam-geneve.xml
@@ -32,6 +32,7 @@
 <!ENTITY I-D.ietf-6man-segment-routing-header SYSTEM "http://xml2rfc.tools.ietf.org/public/rfc/bibxml3/reference.I-D.ietf-6man-segment-routing-header.xml">
 <!ENTITY I-D.ietf-nvo3-geneve SYSTEM "http://xml2rfc.tools.ietf.org/public/rfc/bibxml3/reference.I-D.ietf-nvo3-geneve.xml">
 <!ENTITY I-D.lapukhov-dataplane-probe SYSTEM "http://xml2rfc.tools.ietf.org/public/rfc/bibxml3/reference.I-D.lapukhov-dataplane-probe.xml">
+<!ENTITY I-D.weis-ippm-ioam-eth SYSTEM "http://xml2rfc.tools.ietf.org/public/rfc/bibxml3/reference.I-D.weis-ippm-ioam-eth.xml">
 <!ENTITY I-D.SPUD SYSTEM "http://xml2rfc.tools.ietf.org/public/rfc/bibxml3/reference.I-D.hildebrand-spud-prototype.xml">
 <!ENTITY AFI SYSTEM "http://www.iana.org/assignments/address-family-numbers/address-family-numbers.xml">
 ]>
@@ -60,7 +61,7 @@
 <?rfc subcompact="no" ?>
 <!-- keep one blank line between list items -->
 <!-- end of list of popular I-D processing instructions -->
-<rfc category="std" docName="draft-brockners-ippm-ioam-geneve-04"
+<rfc category="std" docName="draft-brockners-ippm-ioam-geneve-05"
      ipr="trust200902">
   <!-- ipr="full3978"-->
 
@@ -132,7 +133,7 @@
       </address>
     </author>
 
-    <author fullname="Carlos Pignataro" initials="C." surname="Pignataro">
+    <author fullname="Carlos Pignataro" initials="C." surname="Pignataro" role="editor">
       <organization abbrev="Cisco">Cisco Systems, Inc.</organization>
 
       <address>
@@ -149,6 +150,26 @@
         </postal>
 
         <email>cpignata@cisco.com</email>
+      </address>
+    </author>
+
+    <author fullname="Nagendra Kumar Nainar" initials="N." surname="Nainar" role="editor">
+      <organization abbrev="Cisco">Cisco Systems, Inc.</organization>
+
+      <address>
+        <postal>
+          <street>7200-11 Kit Creek Road</street>
+
+          <city>Research Triangle Park</city>
+
+          <region>NC</region>
+
+          <code>27709</code>
+
+          <country>United States</country>
+        </postal>
+
+        <email>naikumar@cisco.com</email>
       </address>
     </author>
 
@@ -361,8 +382,16 @@
     </section>
 
     <section title="IOAM Data Field Encapsulation in Geneve">
-      <t>Geneve is defined in <xref target="I-D.ietf-nvo3-geneve"/>. IOAM data
-      fields are carried in the Geneve header as a tunnel option, using a
+      <t>Geneve is defined in <xref target="I-D.ietf-nvo3-geneve"/>. When 
+      Geneve encapsulation header is used, IOAM data fields can either be carried 
+      after the Geneve header, identified by the next protocol field or can be 
+      carried in the Geneve header itself as a tunnel option. The former approach is 
+      defined in <xref target="I-D.weis-ippm-ioam-eth"/> while the latter approach 
+      is defined in this document. 
+      </t>
+
+      <t>
+      IOAM data fields are carried using a
       single Geneve Option Class TBD_IOAM. The different IOAM data fields
       defined in <xref target="I-D.ietf-ippm-ioam-data"/> are added as TLVs
       using that Geneve Option Class. In an administrative domain where IOAM
@@ -415,7 +444,7 @@
 
           <t hangText="Type:">8-bit field defining the IOAM Option type, as
           defined in Section 7.2 of <xref
-          target="I-D.ietf-ippm-ioam-data"/>.</t>
+          target="I-D.ietf-ippm-ioam-data"/>. The 'C' bit MUST be set to zero.</t>
 
           <t hangText="R (3 bits):">Option control flags reserved for future
           use. The flags MUST be set to zero on transmission and ignored on receipt.</t>
@@ -500,7 +529,7 @@
       </section>
 
       <section title="IOAM and the use of the Geneve O-bit">
-        <t><xref target="I-D.ietf-nvo3-geneve"/> defines an "O bit" for OAM
+        <t><xref target="I-D.ietf-nvo3-geneve"/> defines an "O bit" for Control
         packets. Per <xref target="I-D.ietf-nvo3-geneve"/> the O bit indicates
         that the packet contains a control message instead of data payload.
         Packets that carry IOAM data fields in addition to regular data
@@ -520,6 +549,17 @@
         important to recognize that any interpretation of port numbers --
         except at the endpoints -- may be incorrect, because port numbers are
         meaningful only at the endpoints."</t>
+      </section>
+
+      <section title="Additional Encapsulation Consideration">
+        <t>Geneve encapsulation header supports carrying IOAM data fields either 
+        as part of the tunnel option or as the protocol data unit that follows the Geneve
+        header. An operator may choose to enable either of the options but it is 
+        not recommended to include both in the same data packet.
+        </t>
+
+        <t>
+        </t>
       </section>
     </section>
 
@@ -581,6 +621,8 @@
       &I-D.ietf-ippm-ioam-data;
 
       &I-D.ietf-nvo3-geneve;
+
+      &I-D.weis-ippm-ioam-eth;
 
       &RFC2784;
 

--- a/drafts/draft-brockners-ippm-ioam-geneve.xml
+++ b/drafts/draft-brockners-ippm-ioam-geneve.xml
@@ -426,11 +426,10 @@
           <t hangText="IOAM Option and Data Space:">IOAM option header and
           data is present as defined by the Type field, and is defined in
           Section 4 of <xref target="I-D.ietf-ippm-ioam-data"/>.</t>
-        </list>Multiple IOAM options MAY be included within the Geneve
-      encapsulation. But more than one IOAM options with the same type MUST NOT
-      be included within the Geneve encapsulation. For example, if a Geneve 
-      encapsulation contains two IOAM
-      options before a data payload, there would be two fields with TBD_IOAM
+        </list>Multiple distinct IOAM Option-Types MAY be included within the same 
+        Geneve encapsulation. Each IOAM Option-Type MUST occur at most once within 
+        the same Geneve encapsulation. For example, if a Geneve 
+      encapsulation contains two IOAM Option-Types before a data payload, there would be two fields with TBD_IOAM
       Option Class each, differentiated by the Type field which specifies the
       type of the IOAM data included.</t>
     </section>

--- a/drafts/draft-brockners-ippm-ioam-geneve.xml
+++ b/drafts/draft-brockners-ippm-ioam-geneve.xml
@@ -318,7 +318,8 @@
       <t>In-situ Operations, Administration, and Maintenance (IOAM) records
       operational and telemetry information in the packet while the packet
       traverses a path between two points in the network. This document
-      outlines how IOAM data fields are encapsulated in Geneve.</t>
+      proposes a new Geneve tunnel option and outlines how IOAM data 
+      fields are carried in the option data field.</t>
     </abstract>
   </front>
 
@@ -328,8 +329,10 @@
       the packet traverses a particular network domain. The term "in-situ"
       refers to the fact that the IOAM data fields are added to the data
       packets rather than is being sent within packets specifically dedicated
-      to OAM. This document defines how IOAM data fields are transported as
-      part of the Geneve <xref target="I-D.ietf-nvo3-geneve"/> encapsulation.
+      to OAM. This document proposes a new Geneve tunnel option and defines 
+      how IOAM data fields are transported as
+      part of the tunnel option in the Geneve <xref target="I-D.ietf-nvo3-geneve"/> 
+      encapsulation.
       The IOAM data fields are defined in <xref
       target="I-D.ietf-ippm-ioam-data"/>.</t>
     </section>
@@ -415,7 +418,7 @@
           target="I-D.ietf-ippm-ioam-data"/>.</t>
 
           <t hangText="R (3 bits):">Option control flags reserved for future
-          use. MUST be zero on transmission and ignored on receipt.</t>
+          use. The flags MUST be set to zero on transmission and ignored on receipt.</t>
 
           <t hangText="Length:">5-bit unsigned integer. Length of the IOAM HDR
           in 4-octet units.</t>
@@ -424,7 +427,9 @@
           data is present as defined by the Type field, and is defined in
           Section 4 of <xref target="I-D.ietf-ippm-ioam-data"/>.</t>
         </list>Multiple IOAM options MAY be included within the Geneve
-      encapsulation. For example, if a Geneve encapsulation contains two IOAM
+      encapsulation. But more than one IOAM options with the same type MUST NOT
+      be included within the Geneve encapsulation. For example, if a Geneve 
+      encapsulation contains two IOAM
       options before a data payload, there would be two fields with TBD_IOAM
       Option Class each, differentiated by the Type field which specifies the
       type of the IOAM data included.</t>
@@ -550,8 +555,8 @@
     <section title="Acknowledgements">
       <t>The authors would like to thank Eric Vyncke, Nalini Elkins, Srihari
       Raghavan, Ranganathan T S, Karthik Babu Harichandra Babu, Akshaya
-      Nadahalli, Stefano Previdi, Hemant Singh, Erik Nordmark, LJ Wobker, and
-      Andrew Yourtchenko for the comments and advice.</t>
+      Nadahalli, Stefano Previdi, Hemant Singh, Erik Nordmark, LJ Wobker,
+      Andrew Yourtchenko and Nagendra Kumar Nainar for the comments and advice.</t>
     </section>
   </middle>
 

--- a/drafts/draft-weis-ippm-ioam-eth.xml
+++ b/drafts/draft-weis-ippm-ioam-eth.xml
@@ -500,9 +500,9 @@
       endpoints.</t>
     </section>
 
-    <section anchor="IANA" title="IEEE Considerations">
+    <section anchor="IANA" title="IANA Considerations">
       <t>A new EtherType value is requested to be added to the <xref
-      target="ETYPES"/> IANA registry by IEEE. The description should be "In-situ OAM
+      target="ETYPES"/> IANA registry by IEEE Registration Authority. The description should be "In-situ OAM
       (IOAM)".</t>
     </section>
 

--- a/drafts/draft-weis-ippm-ioam-eth.xml
+++ b/drafts/draft-weis-ippm-ioam-eth.xml
@@ -295,7 +295,7 @@
       being sent within packets specifically dedicated to OAM. This document
       proposes a new Ethertype for IOAM and defines how IOAM data fields are 
       carried as part of encapsulations where
-      the IOAM data follows an encapsulation header that uses an EtherType to 
+      the IOAM data fields follows an encapsulation header that uses an EtherType to 
       denote the next
       protocol in the packet. Examples of these protocols are GRE <xref
       target="RFC2890"/> and Geneve <xref target="I-D.ietf-nvo3-geneve"/>).
@@ -338,8 +338,8 @@
       identifies the next protocol using an EtherType (e.g., GRE or Geneve)
       the presence of IOAM data fields are identified with TBD_IOAM. When this
       EtherType is used, an additional IOAM header is also included. This
-      header indicates the type of IOAM data that follows, and the next
-      protocol that follows the IOAM data.</t>
+      header indicates the type of IOAM data fields that follows, and the next
+      protocol that follows the IOAM data fields.</t>
 
       <figure>
         <artwork align="center"><![CDATA[ 0                   1                   2                   3
@@ -421,8 +421,8 @@
         target="RFC2890"/>. The GRE Protocol Type value is TBD_IOAM.</t>
 
         <t><xref target="GRE-example"/> shows two example protocol header
-        stacks that use GRE along with IOAM. IOAM-Option-Types (the below
-        diagram uses "IOAM" as shorthand for IOAM-Option-Types) are sequenced
+        stacks that use GRE along with IOAM. IOAM Option-Types (the below
+        diagram uses "IOAM" as shorthand for IOAM Option-Types) are sequenced
         in behind the GRE header that follows the "outer" IP header.</t>
 
         <t><figure align="center" anchor="GRE-example"

--- a/drafts/draft-weis-ippm-ioam-eth.xml
+++ b/drafts/draft-weis-ippm-ioam-eth.xml
@@ -8,6 +8,7 @@
 <!ENTITY RFC2890 SYSTEM "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.2890.xml">
 <!ENTITY RFC4303 SYSTEM "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.4303.xml">
 <!ENTITY RFC8174 SYSTEM "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.8174.xml">
+<!ENTITY RFC2784 SYSTEM "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.2784.xml">
 <!ENTITY I-D.ietf-ippm-ioam-data SYSTEM "http://xml2rfc.tools.ietf.org/public/rfc/bibxml3/reference.I-D.ietf-ippm-ioam-data.xml">
 <!ENTITY I-D.ietf-nvo3-geneve SYSTEM "http://xml2rfc.tools.ietf.org/public/rfc/bibxml3/reference.I-D.ietf-nvo3-geneve.xml">
 ]>
@@ -16,7 +17,7 @@
 <?rfc tocdepth="3"?>
 <?rfc symrefs="yes"?>
 <?rfc sortrefs="yes"?>
-<rfc category="std" docName="draft-weis-ippm-ioam-eth-04" ipr="trust200902">
+<rfc category="std" docName="draft-weis-ippm-ioam-eth-05" ipr="trust200902">
   <front>
     <title abbrev="EtherType IOAM">EtherType Protocol Identification of
     In-situ OAM Data</title>
@@ -117,7 +118,7 @@
       </address>
     </author>
 
-    <author fullname="Carlos Pignataro" initials="C." surname="Pignataro">
+    <author fullname="Carlos Pignataro" initials="C." surname="Pignataro" role="Editor">
       <organization abbrev="Cisco">Cisco Systems, Inc.</organization>
 
       <address>
@@ -134,6 +135,26 @@
         </postal>
 
         <email>cpignata@cisco.com</email>
+      </address>
+    </author>
+
+    <author fullname="Nagendra Kumar Nainar" initials="N." surname="Nainar" role="Editor">
+      <organization abbrev="Cisco">Cisco Systems, Inc.</organization>
+
+      <address>
+        <postal>
+          <street>7200-11 Kit Creek Road</street>
+
+          <city>Research Triangle Park</city>
+
+          <region>NC</region>
+
+          <code>27709</code>
+
+          <country>United States</country>
+        </postal>
+
+        <email>naikumar@cisco.com</email>
       </address>
     </author>
 
@@ -296,11 +317,11 @@
       proposes a new Ethertype for IOAM and defines how IOAM data fields are 
       carried as part of encapsulations where
       the IOAM data fields follows an encapsulation header that uses an EtherType to 
-      denote the next
-      protocol in the packet. Examples of these protocols are GRE <xref
+      denote the type of protocol data unit. Examples of these protocols are GRE <xref
+      target="RFC2784"/> <xref
       target="RFC2890"/> and Geneve <xref target="I-D.ietf-nvo3-geneve"/>).
       This document outlines how IOAM data fields are encoded in these
-      protocols.</t>
+      encapsultion headers.</t>
     </section>
 
     <section title="Conventions">
@@ -366,7 +387,7 @@
           of the IOAM header in 4-octet units.</t>
 
           <t hangText="Next Protocol:">16 bits Next Protocol Type field
-          contains the protocol type of the packet following IOAM protocol
+          contains the protocol type of the protocol data unit following IOAM protocol
           header. Protocol Type is defined to be an EtherType value from <xref
           target="ETYPES"/>. An implementation receiving a packet containing a
           Protocol Type which is not listed in one of those registries SHOULD
@@ -375,16 +396,18 @@
           <t hangText="IOAM Option and Data Space:">IOAM option header and
           data is present as specified by the IOAM-Type field, and is defined
           in Section 4 of <xref target="I-D.ietf-ippm-ioam-data"/>.</t>
-        </list>Multiple IOAM options MAY be included within the IOAM Option
-      and Data Space. For example, if two IOAM options are included, the Next
-      Protocol field of the first IOAM option will contain the value of
+        </list>Multiple IOAM options MAY be included within the encapsulation header. 
+        For example, if a GRE encapsulation contains two IOAM options before the data 
+        payload, the Next Protocol field of the first IOAM option will contain the value of
       TBD_IOAM, while the Next Protocol field of the second IOAM option will
-      contain the EtherType indicating the type of the data packet.</t>
+      contain the EtherType indicating the type of the data payload.</t>
     </section>
 
     <section title="Usage Examples of the IOAM EtherType">
-      <t>The IOAM EtherType can be used with many encapsulations. The
-      following sections show how it can be used with GRE and Geneve.</t>
+      <t>The IOAM EtherType can be used with any encapsulation that uses EtherType
+      to denote the type of the protocol data unit. The
+      following sections show how it can be used when GRE and Geneve are used as 
+      the encapsulation header.</t>
 
       <section title="Example: GRE Encapsulation of IOAM Data Fields">
         <t>When IOAM data fields are carried in GRE, the IOAM encapsulation
@@ -418,12 +441,13 @@
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 ]]></artwork>
           </figure>The GRE header and fields are defined in <xref
-        target="RFC2890"/>. The GRE Protocol Type value is TBD_IOAM.</t>
+        target="RFC2890"/>. The GRE Protocol Type value is set to TBD_IOAM.</t>
 
         <t><xref target="GRE-example"/> shows two example protocol header
         stacks that use GRE along with IOAM. IOAM Option-Types (the below
         diagram uses "IOAM" as shorthand for IOAM Option-Types) are sequenced
-        in behind the GRE header that follows the "outer" IP header.</t>
+        in behind the GRE header that follows the "outer" header of the 
+        next protocol unit.</t>
 
         <t><figure align="center" anchor="GRE-example"
             title="GRE with IOAM examples">
@@ -478,21 +502,24 @@
 |                                                               |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 ]]></artwork>
-          </figure>The GENEVE header and fields are defined in <xref
+          </figure>The Geneve header and fields are defined in <xref
         target="I-D.ietf-nvo3-geneve"/>. The Geneve Protocol Type value is
         TBD_IOAM.</t>
       </section>
     </section>
 
     <section title="Security Considerations">
-      <t>This document describes the encapsulation of IOAM data fields in GRE.
+      <t>This document describes the encapsulation of IOAM data fields in the encapsulation
+      header such as GRE and Geneve that uses EtherType to denote the protocol data unit.
       Security considerations of the specific IOAM data fields for each case
-      (i.e., Trace, Proof of Transit, and E2E) are described in defined in
+      (i.e., Trace, Proof of Transit, and E2E) are described in
       <xref target="I-D.ietf-ippm-ioam-data"/>.</t>
 
       <t>As this document describes new protocol fields within the existing
-      GRE encapsulation, these are similar to the security considerations of
-      <xref target="RFC2890"/>.</t>
+      encapsulation, any security considerations of the respective encapsulation
+      header is applicable. When the encapsulation is GRE, the security considerations of
+      <xref target="RFC2890"/> is applicable.  When the encapsulation is Geneve, the 
+      security considerations of <xref target="I-D.ietf-nvo3-geneve"/> is applicable.</t>
 
       <t>IOAM data transported in an OAM E2E header SHOULD be integrity
       protected (e.g., with IPsec ESP <xref target="RFC4303"/>) to detect
@@ -522,6 +549,8 @@
       &RFC8174;
 
       &RFC2890;
+
+      &RFC2784;
 
       &I-D.ietf-ippm-ioam-data;
 

--- a/drafts/draft-weis-ippm-ioam-eth.xml
+++ b/drafts/draft-weis-ippm-ioam-eth.xml
@@ -16,7 +16,7 @@
 <?rfc tocdepth="3"?>
 <?rfc symrefs="yes"?>
 <?rfc sortrefs="yes"?>
-<rfc category="std" docName="draft-weis-ippm-ioam-eth-03" ipr="trust200902">
+<rfc category="std" docName="draft-weis-ippm-ioam-eth-04" ipr="trust200902">
   <front>
     <title abbrev="EtherType IOAM">EtherType Protocol Identification of
     In-situ OAM Data</title>
@@ -293,8 +293,10 @@
       traverses a particular network domain. The term "in-situ" refers to the
       fact that the IOAM data fields are added to the data packets rather than
       being sent within packets specifically dedicated to OAM. This document
-      defines how IOAM data fields are carried as part of encapsulations where
-      the IOAM data follows a header that uses an EtherType to denote the next
+      proposes a new Ethertype for IOAM and defines how IOAM data fields are 
+      carried as part of encapsulations where
+      the IOAM data follows an encapsulation header that uses an EtherType to 
+      denote the next
       protocol in the packet. Examples of these protocols are GRE <xref
       target="RFC2890"/> and Geneve <xref target="I-D.ietf-nvo3-geneve"/>).
       This document outlines how IOAM data fields are encoded in these
@@ -498,12 +500,16 @@
       endpoints.</t>
     </section>
 
-    <section anchor="IANA" title="IANA Considerations">
+    <section anchor="IANA" title="IEEE Considerations">
       <t>A new EtherType value is requested to be added to the <xref
-      target="ETYPES"/> IANA registry. The description should be "In-situ OAM
+      target="ETYPES"/> IANA registry by IEEE. The description should be "In-situ OAM
       (IOAM)".</t>
     </section>
 
+    <section anchor="Acknowledgments" title="Acknowledgements">
+      <t>We would like to thank Nagendra Kumar Nainar for the contribution.
+      </t>
+    </section>
     <!-- <section anchor="Acknowledgements" title="Acknowledgements"> -->
 
     <!-- </section> -->


### PR DESCRIPTION
Updated additional clarity to the use of Option Class and Next Protocol in Geneve.
Updated additional clarity for terminology consistency.
Updated the editor lists.