### PR TITLE
Revert O-bit value "1" to mean overflowed

### DIFF
--- a/drafts/draft-ietf-ippm-ioam-data.xml
+++ b/drafts/draft-ietf-ippm-ioam-data.xml
@@ -742,7 +742,7 @@ The trace option data MUST be 4-octet aligned:
               target="Flags-Registry-Sec"/>. This document allocates a single
               flag as follows: <list style="hanging">
                   <t hangText="Bit 0">"Overflow" (O-bit) (most significant
-                  bit). If there are not enought octets left to record node
+                  bit). If there are not enough octets left to record node
                   data, the network element MUST NOT add any fields and MUST set
                   the overflow "O-bit" to "1" in the IOAM-Trace-Option header.
                   This is useful for transit nodes to ignore further

--- a/drafts/draft-ietf-ippm-ioam-data.xml
+++ b/drafts/draft-ietf-ippm-ioam-data.xml
@@ -743,8 +743,8 @@ The trace option data MUST be 4-octet aligned:
               flag as follows: <list style="hanging">
                   <t hangText="Bit 0">"Overflow" (O-bit) (most significant
                   bit). If there are not enought octets left to record node
-                  data, the network element MUST NOT add a field and MUST set
-                  the overflow "O-bit" to "0" in the IOAM-Trace-Option header.
+                  data, the network element MUST NOT add any fields and MUST set
+                  the overflow "O-bit" to "1" in the IOAM-Trace-Option header.
                   This is useful for transit nodes to ignore further
                   processing of the option.</t>
                 </list></t>

--- a/drafts/draft-ietf-ippm-ioam-data.xml
+++ b/drafts/draft-ietf-ippm-ioam-data.xml
@@ -1749,9 +1749,9 @@ be 4-octet aligned:
     <section anchor="IANA" title="IANA Considerations">
       <t>This document requests the following IANA Actions.</t>
 
-      <t>IANA is requested to define a registry group named 
-	  "In-Situ OAM (IOAM) Protocol Parameters".</t> 
-	  
+      <t>IANA is requested to define a registry group named
+	  "In-Situ OAM (IOAM) Protocol Parameters".</t>
+
 	  <t>This group will include the following registries:</t>
 
         <t><list style="empty">
@@ -1772,10 +1772,9 @@ be 4-octet aligned:
 
         <t>New registries in this group can be created via RFC
         Required process as per <xref target="RFC8126"/>.</t>
-		
+
         <t>The subsequent sub-sections detail the registries herein
         contained.</t>
-      </section>
 
       <section anchor="IOAM-type-registry" title="IOAM Option-Type Registry">
         <t>This registry defines 128 code points for the IOAM Option-Type


### PR DESCRIPTION
An "editorial" change modified the text about setting the O-bit, saying
that the bit should be set to "0". This is non-intuitive, and leaves it
unclear when the bit would be set to "1".

This commit changes the text to set the bit to "1" when there are
insufficient octets to record node data.

Also, the IANA considerations section has an extra closing tag which prevents
xml2rfc from working properly.