### PR TITLE
Genart comments

### DIFF
--- a/drafts/draft-ietf-ippm-ioam-data.xml
+++ b/drafts/draft-ietf-ippm-ioam-data.xml
@@ -278,7 +278,8 @@
       types for in-situ OAM. The in-situ OAM data field can be encapsulated in
       a variety of protocols, including NSH, Segment Routing, Geneve, IPv6, or
       IPv4. Specification details for these different protocols are outside
-      the scope of this document.</t>
+      the scope of this document. It is expected that each such encapsulation
+	  will be defined in the relevant working group in the IETF.GGG</t>
 
       <t>Deployment domain (or scope) of in-situ OAM deployment: IOAM is a
       network domain focused feature, with "network domain" being a set of
@@ -1132,7 +1133,7 @@ The trace option data MUST be 4-octet aligned:
             interpreted within the context of an IOAM-Namespace and/or
             node-id if used. The authors acknowledge that in some operational
             cases there is a need for the units to be consistent across a
-            packet path through the network, hence RECOMMEND the
+            packet path through the network, hence it is RECOMMENDED for
             implementations to use standard units such as Bytes. <figure>
                 <artwork><![CDATA[ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -1918,7 +1919,8 @@ be 4-octet aligned:
         Review" policy defined in <xref target="RFC8126"/>. Upon a new 
 		allocation request, the responsible AD will appoint a designated 
 		expert, who will review the allocation request. The expert will post 
-		the request on the IPPM mailing list, and possibly on other relevant 
+		the request on the mailing list of the IPPM working group in the IETF
+		(ippm@ietf.org), and possibly on other relevant 
 		mailing lists, to allow for community feedback. Based on the review, 
 		the expert will either approve or deny the request. The intention is 
 		that any allocation will be accompanied by a published RFC.  But in 

--- a/drafts/draft-ietf-ippm-ioam-data.xml
+++ b/drafts/draft-ietf-ippm-ioam-data.xml
@@ -2196,12 +2196,12 @@ be 4-octet aligned:
 
    
    Barak Gafni
-   Mellanox Technologies, Inc.
+   Nvidia
    350 Oakmead Parkway, Suite 100
    Sunnyvale, CA  94085
    U.S.A.
 
-   Email: gbarak@mellanox.com
+   Email: gbarak@nvidia.com
 
    
    Jennifer Lemon

--- a/drafts/draft-ietf-ippm-ioam-data.xml
+++ b/drafts/draft-ietf-ippm-ioam-data.xml
@@ -279,7 +279,7 @@
       a variety of protocols, including NSH, Segment Routing, Geneve, IPv6, or
       IPv4. Specification details for these different protocols are outside
       the scope of this document. It is expected that each such encapsulation
-	  will be defined in the relevant working group in the IETF.GGG</t>
+	  will be defined in the relevant working group in the IETF.</t>
 
       <t>Deployment domain (or scope) of in-situ OAM deployment: IOAM is a
       network domain focused feature, with "network domain" being a set of


### PR DESCRIPTION
Addressed the three comments from the Genart review:
https://datatracker.ietf.org/doc/review-ietf-ippm-ioam-data-11-genart-lc-romascanu-2020-12-05/


1. How are specific IOAM encapsulations being defined? Will specifications that define IOAM encapsulations into various protocols be within the scope of the IPPM WG? of the IETF? Do they require to be RFCs? Some clarification text would be useful. 

2. In Section 5.4.2.12 I found the following: 

> The authors
   acknowledge that in some operational cases there is a need for the
   units to be consistent across a packet path through the network,
   hence RECOMMEND the implementations to use standard units such as
   Bytes.

'The authors ... RECOMMEND' seems a little bit odd. The active verb form is not within the list of keywords as per [RFC2119], also mentioned in Section 3 of this document. To be on the safe side I would recommend reformulating the sentence so that the RECOMMENDED form is used. Alternatively, just do not use capitalization here. 

3. In Section 8.7 I found:

> The expert will post the request on the IPPM mailing list, and
   possibly on other relevant mailing lists, to allow for community
   feedback. 

I assume that this means the IPPM WG mailing list. The abbreviation of IPPM may be very familiar for the current audiences, but the situation may change in the future. The scope even of this document may outlive the WG. I suggest to expand IPPM in Section 3 and possibly reformulate the sentence so that posting the request on the IPPM list does not sound as the eternal procedure. 
 
