### PR TITLE
draft-mizrahi-ippm-ioam-linux-profile - Minor changes

### DIFF
--- a/drafts/draft-mizrahi-ippm-ioam-linux-profile.xml
+++ b/drafts/draft-mizrahi-ippm-ioam-linux-profile.xml
@@ -28,6 +28,14 @@
         <email>email@gmail.com</email>
       </address>
     </author>
+    
+    <author fullname="Justin Iurman" initials="J." surname="Iurman">
+      <organization abbrev="">Université de Liège</organization>
+
+      <address>
+        <email>justin.iurman@uliege.be</email>
+      </address>
+    </author>
 
     <date year="2021"/>
 
@@ -118,7 +126,7 @@
       +---------+-----------+-----------------------------------------+
       | IPv6    | IPv6      |                                         |
       |         | Extension |            Original Packet              |
-      | Header  | Headers   |                                         |
+      | Header  | Header    |                                         |
       +---------+-----------+-----------------------------------------+
 
 	  ]]></artwork>
@@ -138,14 +146,14 @@
 		  
    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
    |  Next Header  |  Hdr Ext Len  |            Padding            |
-   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-   |  Option Type  |  Opt Data Len |   Reserved    |   IOAM Type   |
    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+<-+
-   |        Namespace-ID           |NodeLen  | Flags | RemainingLen|  |
+   |  Option Type  |  Opt Data Len |   Reserved    |   IOAM Type   |  |
    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+  I
-   |               IOAM-Trace-Type                 |  Reserved     |  O
+   |        Namespace-ID           |NodeLen  | Flags | RemainingLen|  O
    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+  A
-   |                                                               |  M
+   |               IOAM-Trace-Type                 |  Reserved     |  M
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+  .
+   |                                                               |  .
    .                                                               .  .
    .                          Option Data                          .  O
    .                                                               .  P
@@ -163,7 +171,7 @@
   	  <section title="IOAM Supported Data Fields">
 	  
 	  <t>The current profile supports all the data field types that are defined
-	  in [draft-ietf-ippm-ioam-data-14].</t>
+	  in [draft-ietf-ippm-ioam-data-14] for the Pre-allocated Trace option.</t>
 	  
 	  <t>Note that the Linux implementation does not update the 
 	  Checksum Complement field and the Transit Delay field when functioning as
@@ -179,7 +187,7 @@
       </section>
 	  
   	  <section title="Opaque State Snapshot">
-		<t>TBD.</t>
+		<t>This profile supports the Opaque State Snapshot option.</t>
       </section>
 	  
       <section title="Timestamp Format">
@@ -207,7 +215,6 @@
 
     <section anchor="IANA" title="IANA Considerations">
       <t>This document does not include any requests from IANA.</t>
-      <t>[RFC-Editor Note: feel free to remove this Section.]</t>
 
     </section>
 


### PR DESCRIPTION
Quick first pass, some minor changes applied. I kept the IPv6
encapsulation section as is but, for now, it is not included in the
kernel implementation (only the direct insertion is supported). However,
this is just a matter of time so I guess it's OK to keep it here until
that. Same remark applies for both the queue depth and buffer occupancy
data fields.

Signed-off-by: Justin Iurman <justin.iurman@uliege.be>