### PR TITLE
draft-mizrahi-ippm-ioam-linux-profile - Queue depth support

### DIFF
--- a/drafts/draft-mizrahi-ippm-ioam-linux-profile.xml
+++ b/drafts/draft-mizrahi-ippm-ioam-linux-profile.xml
@@ -303,7 +303,7 @@
 
         <c>Queue depth</c>
 
-        <c>Passive support</c>
+        <c>Supported*</c>
 
         <c>Checksum complement</c>
 
@@ -329,6 +329,9 @@
 
         <c>Supported</c>
       </texttable>
+
+      <t>*: Queue depth is supported starting from the Linux 5.17 kernel, and has
+      passive support for older kernel versions.</t>
 
       <t>Both the Opaque State Snapshot and the Namespace specific data are
       supported in the Linux implementation by incorporating configurable


### PR DESCRIPTION
Add a note about the queue depth being fully supported starting from the
Linux 5.17 kernel (has passive support for older kernel versions).

Signed-off-by: Justin Iurman <justin.iurman@uliege.be>