### PR TITLE
draft-ietf-ippm-ioam-data-integrity: Major review

### DIFF
--- a/drafts/draft-ietf-ippm-ioam-data-integrity.xml
+++ b/drafts/draft-ietf-ippm-ioam-data-integrity.xml
@@ -93,7 +93,7 @@
     <!-- The abbreviated title is used in the page header - it is only necessary if the 
          full title is longer than 39 characters -->
 
-    <title abbrev="IOAM Data Fields Integrity">Integrity of In-situ OAM Data
+    <title abbrev="IOAM-Data-Fields Integrity">Integrity of In-situ OAM Data
     Fields</title>
 
     <!-- add 'role="editor"' below for the editors if appropriate -->
@@ -213,7 +213,7 @@
       operational and telemetry information in the packet while the packet
       traverses a path in the network. IETF protocols require features to
       ensure their security. This document describes the integrity protection
-      of IOAM data fields.</t>
+      of IOAM-Data-Fields.</t>
     </abstract>
   </front>
 
@@ -241,39 +241,39 @@
       <t>The current <xref target="I-D.ietf-ippm-ioam-data"/> assumes that
       IOAM is deployed in limited domains, where an operator has
       means to select, monitor, and control the access to all the networking
-      devices, making the domain a trusted network. As such, IOAM data fields
+      devices, making the domain a trusted network. As such, IOAM-Data-Fields
       are carried in clear within packets and there are no protections against
       any node or middlebox tampering with the data. 
-      IOAM data fields collected in an untrusted or semi-trusted environment
+      IOAM-Data-Fields collected in an untrusted or semi-trusted environment
       require integrity protection to support critical operational decisions.
       </t>
 
       <t>The following considerations and
       requirements are to be taken into account in addition to addressing the
-      problem of detectability of any integrity breach of the IOAM data fields
+      problem of detectability of any integrity breach of the IOAM-Data-Fields
       collected: <list style="numbers">
           <t>IOAM data is processed by the data plane, hence viability
-          of any method to prove integrity of the IOAM data fields must be
+          of any method to prove integrity of the IOAM-Data-Fields must be
           feasible at data plane processing/forwarding rates (IOAM might
           be applied to all traffic a router forwards).</t>
 
           <t>IOAM data is carried within packets. Additional space
-          required to prove integrity of the IOAM data fields needs to be optimal, i.e.
+          required to prove integrity of the IOAM-Data-Fields needs to be optimal, i.e.
           should not exceed the MTU or have adverse effect on packet
           processing.</t>
 
           <t>Replay protection of older IOAM data should be possible.
           Without replay protection, a rogue node can present the old IOAM
           data, masking any ongoing network issues/activity and making the
-          IOAM data fields collection useless.</t>
+          IOAM-Data-Fields collection useless.</t>
 
       </list></t>
 
-      <t>This document defines the methods to protect the integrity of IOAM
-	      data fields, using the IOAM Option-Types
+      <t>This document defines the methods to protect the integrity of
+	      IOAM-Data-Fields, using the IOAM Option-Types
 	      specified in <xref target="I-D.ietf-ippm-ioam-data"/>
 	      as an example. The methods similarily apply to
-		      other IOAM Option-Types with data fields.</t>
+		      other IOAM Option-Types which contain IOAM-Data-Fields.</t>
     </section>
 
     <section anchor="Conventions" title="Conventions">
@@ -308,9 +308,9 @@
       other layers are handled by security mechanisms that are deployed at
       these layers.</t>
 
-      <t>This document is focused on integrity protection for IOAM data
-      fields. Thus the threat analysis includes threats that are related to or
-      result from compromising the integrity of IOAM data fields. Other
+      <t>This document is focused on integrity protection for IOAM-Data-Fields.
+      Thus the threat analysis includes threats that are related to or
+      result from compromising the integrity of IOAM-Data-Fields. Other
       security aspects such as confidentiality are not within the scope of
       this document.</t>
 
@@ -332,16 +332,16 @@
       necessary. Beyond these general impacts, threat-specific impacts are
       discussed in each of the subsections below.</t>
 
-      <section anchor="ModifDataSec" title="Modification: IOAM Data Fields">
+      <section anchor="ModifDataSec" title="Modification: IOAM-Data-Fields">
         <t>Threat <list hangIndent="10" style="empty">
-            <t>An attacker can maliciously modify the IOAM data fields of
+            <t>An attacker can maliciously modify the IOAM-Data-Fields of
             in-transit packets. The modification can either be applied to all
             packets or selectively applied to a subset of the en route
             packets. This threat is applicable to on-path attackers.</t>
           </list></t>
 
         <t>Impact <list hangIndent="10" style="empty">
-            <t>By systematically modifying the IOAM data fields of some or all
+            <t>By systematically modifying the IOAM-Data-Fields of some or all
             of the in-transit packets, an attacker can create a false picture
             of the paths in the network, the existence of faulty nodes and
             their location, and the network performance.</t>
@@ -353,26 +353,26 @@
         <t>Threat <list hangIndent="10" style="empty">
             <t>An on-path attacker can modify the header in IOAM Option-Types
             in order to change or disrupt the
-            behavior of nodes processing IOAM data fields along the path. This
+            behavior of nodes processing IOAM-Data-Fields along the path. This
             threat is not within the scope of this document.</t>
           </list></t>
 
         <t>Impact <list hangIndent="10" style="empty">
             <t>Changing the header of IOAM Option-Types may have several
             implications. An attacker can maliciously increase the processing
-            overhead in nodes that process IOAM data fields and increase the
-            on-the-wire overhead of IOAM data fields, for example by modifying
+            overhead in nodes that process IOAM-Data-Fields and increase the
+            on-the-wire overhead of IOAM-Data-Fields, for example by modifying
             the IOAM-Trace-Type field in the IOAM Trace Option-Type header. An
-            attacker can also prevent some of the nodes that process IOAM data
-            fields from incorporating IOAM data fields by modifying the
-            RemainingLen field.</t>
+            attacker can also prevent some of the nodes that process
+            IOAM-Data-Fields from incorporating IOAM-Data-Fields, by modifying
+            the RemainingLen field in the IOAM Trace Option-Type header.</t>
           </list></t>
       </section>
 
-      <section title="Injection: IOAM Data Fields">
+      <section title="Injection: IOAM-Data-Fields">
         <t>Threat <list hangIndent="10" style="empty">
-            <t>An attacker can inject packets with IOAM Option-Types and IOAM
-            data fields. This threat is applicable to both on-path and
+            <t>An attacker can inject packets with IOAM Option-Types and
+            IOAM-Data-Fields. This threat is applicable to both on-path and
             off-path attackers.</t>
           </list></t>
 
@@ -385,7 +385,7 @@
       <section title="Injection: IOAM Option-Type Headers">
         <t>Threat <list hangIndent="10" style="empty">
             <t>An attacker can inject packets with IOAM Option-Type headers,
-            thus manipulating other nodes that process IOAM data fields in the
+            thus manipulating other nodes that process IOAM-Data-Fields in the
             network. This threat is applicable to both on-path and off-path
             attackers. This threat is not within the scope of this document.</t>
           </list></t>
@@ -398,9 +398,9 @@
 
       <section title="Management and Exporting">
         <t>Threat <list hangIndent="10" style="empty">
-            <t>Attacks that compromise the integrity of IOAM data fields can
+            <t>Attacks that compromise the integrity of IOAM-Data-Fields can
             be applied at the management plane, e.g., by manipulating network
-            management packets. Furthermore, the integrity of IOAM data fields
+            management packets. Furthermore, the integrity of IOAM-Data-Fields
             that are exported to a receiving entity can also be compromised.
             Management plane attacks are not within the scope of this
             document; the network management protocol is expected to include
@@ -412,10 +412,10 @@
 
         <t>Impact <list hangIndent="10" style="empty">
             <t>Malicious manipulation of the management protocol can cause
-            nodes that process IOAM data fields to malfunction, to be
-            overloaded, or to incorporate unnecessary IOAM data fields into
+            nodes that process IOAM-Data-Fields to malfunction, to be
+            overloaded, or to incorporate unnecessary IOAM-Data-Fields into
             user packets. The impact of compromising the integrity of exported
-            IOAM data fields is similar to the impacts of previous threats
+            IOAM-Data-Fields is similar to the impacts of previous threats
             that were described in this section.</t>
           </list></t>
       </section>
@@ -423,7 +423,7 @@
       <section title="Delay">
         <t>Threat <list hangIndent="10" style="empty">
             <t>An on-path attacker may delay some or all of the in-transit
-            packets that include IOAM data fields in order to create the false
+            packets that include IOAM-Data-Fields in order to create the false
             illusion of congestion. Delay attacks are well known in the
             context of deterministic networks <xref
             target="I-D.ietf-detnet-security"/> and synchronization <xref
@@ -439,8 +439,8 @@
 
         <t>Impact <list hangIndent="10" style="empty">
             <t>Since IOAM can be applied to a fraction of the traffic, an
-            attacker can detect and delay only the packets that include IOAM
-            data fields, thus preventing the authenticity of delay and load
+            attacker can detect and delay only the packets that include
+            IOAM-Data-Fields, thus preventing the authenticity of delay and load
             measurements.</t>
           </list></t>
       </section>
@@ -453,11 +453,11 @@
 +-------------------------------------------+--------+------------+
 | Threat                                    |In scope|Out of scope|
 +-------------------------------------------+--------+------------+
-|Modification: IOAM Data Fields             |   +    |            |
+|Modification: IOAM-Data-Fields             |   +    |            |
 +-------------------------------------------+--------+------------+
 |Modification: IOAM Option-Type Headers     |        |     +      |
 +-------------------------------------------+--------+------------+
-|Injection: IOAM Data Fields                |   +    |            |
+|Injection: IOAM-Data-Fields                |   +    |            |
 +-------------------------------------------+--------+------------+
 |Injection: IOAM Option-Type Headers        |        |     +      |
 +-------------------------------------------+--------+------------+
@@ -472,7 +472,7 @@
 
     <section title="Integrity Protected Option-Types">
     <t>This section defines new IOAM Option-Types to be allocated in the IOAM
-    Option-Type Registry. Their purpose is to carry IOAM data fields with
+    Option-Type Registry. Their purpose is to carry IOAM-Data-Fields with
     integrity protection. Each of the IOAM Option-Types defined in <xref
     target="I-D.ietf-ippm-ioam-data"/> is extended as follows:</t>
 
@@ -516,7 +516,7 @@
       <t><list style="hanging">
         <t hangText="Signature-suite:">8-bit unsigned integer. 
         This field defines the algorithms used to compute the digest 
-        and the signature over the Option-Type data fields.</t>
+        and the signature over the IOAM-Data-Fields.</t>
 
         <t hangText="Nonce length:">8-bit unsigned integer. This field
         specifies the length of the Nonce in octets.</t>
@@ -611,22 +611,22 @@
         <list style="numbers">
           <t>The encapsulating node creates a nonce and stores it in the Nonce
           field of the Integrity Protection subheader. The signature is
-          generated over the Nonce field and the hash of data fields it has
-          inserted, i.e., sign(Nonce || hash(data fields)). Data fields that
+          generated over the Nonce field and the hash of IOAM-Data-Fields it has
+          inserted, i.e., sign(Nonce || hash(IOAM-Data-Fields)). IOAM-Data-Fields that
           will be updated in-place MUST be excluded from the signature (e.g.,
           the POT Cumulative field). The signature is stored in the Signature
           field of the Integrity Protection subheader. Important note: if all
-          the inserted data fields will be updated in-place, or if there is no
-          data field at all, the encapsulating node MUST NOT use an Integrity
+          the inserted IOAM-Data-Fields are to be updated in-place, or if there is no
+          IOAM-Data-Field at all, the encapsulating node MUST NOT use an Integrity
           Protected Option-Type.</t>
 
           <t>A transit node generates a signature over the Signature field and
-          the hash of data fields it has inserted, i.e.,
-          sign(Signature || hash(data fields)). Data fields that are updated
+          the hash of IOAM-Data-Fields it has inserted, i.e.,
+          sign(Signature || hash(IOAM-Data-Fields)). IOAM-Data-Fields that are updated
           in-place MUST be excluded from the signature (e.g., the POT Cumulative
           field). The signature is stored in the Signature field of the
-          Integrity Protection subheader. Important note: if all the data fields
-          involved are updated in-place, or if there is no data field involved,
+          Integrity Protection subheader. Important note: if all the IOAM-Data-Fields
+          involved are updated in-place, or if there is no IOAM-Data-Field involved,
           the transit node MUST NOT generate a signature and MUST NOT update the
           Signature field.</t>
 
@@ -635,7 +635,7 @@
           decapsulating node is also the Validator, for obvious performance
           reasons.</t>
 
-          <t>The Validator recreates the signature over data fields collected
+          <t>The Validator recreates the signature over IOAM-Data-Fields collected
           and checks the integrity against the Signature field. In order to
           recompute the signature, the Validator iteratively follows the same
           procedure as for the encapsulating, transit and decapsulating nodes,
@@ -665,7 +665,7 @@
 
         <t>The Signature consumes 32 octets with AES-256. With
         this method, the Signature is carried only once for the entire
-        packet. As there are dedicated options for carrying IOAM data with
+        packet. As there are dedicated options for carrying IOAM-Data-Fields with
         integrity protection, in case of performance concerns in computing
         signature and validating it, these options can be used for a subset
         of the packets by using sampling of data to enable IOAM with
@@ -692,7 +692,7 @@
         <t>The Signature consumes 32 octets with ECDSA
         P-256. With this method, the Signature is
         carried only once for the entire packet. As there are dedicated
-        options for carrying IOAM data with integrity protection, in case of
+        options for carrying IOAM-Data-Fields with integrity protection, in case of
         performance concerns in computing signature and validating it,
         these options can be used for a subset of the packets by using
         sampling of data to enable IOAM with integrity protection.</t>

--- a/drafts/draft-ietf-ippm-ioam-data-integrity.xml
+++ b/drafts/draft-ietf-ippm-ioam-data-integrity.xml
@@ -603,10 +603,14 @@
       </section>
     </section>
 
-    <section title="Methods for integrity protection">
-      <t>Methods for integrity protection can leverage symmetric or asymmetric
-      key based signatures, as described in the subsections below. Both methods
-      work as follows:
+    <section title="Methods for space optimized integrity protection">
+      <t>Methods for space optimized integrity protection can leverage symmetric
+      or asymmetric key based signatures, as described in the subsections below.
+      The Signature consumes 32 octets and is carried only once for the entire
+      packet. In case of performance concerns, such method can be applied to a
+      subset of the traffic by using sampling of data to enable IOAM with
+      integrity protection. Both symmetric and asymmetric signature methods work
+      as follows:
 
         <list style="numbers">
           <t>The encapsulating node creates a nonce and stores it in the Nonce
@@ -654,22 +658,8 @@
         all the keys). The details of the mechanisms responsible for key
         distribution are outside the scope of this document.</t>
 
-        <t>This method uses the following algorithms:
-          <list style="numbers">
-            <t>The signature algorithm MUST be Advanced Encryption Standard
-            (AES) AES-256. <xref target="AES"/> <xref target="NIST.800-38D"/>.</t>
-
-            <t>The digest/hash algorithm MUST be SHA-256 <xref target="SHS"/>.</t>
-          </list>
-        </t>
-
-        <t>The Signature consumes 32 octets with AES-256. With
-        this method, the Signature is carried only once for the entire
-        packet. As there are dedicated options for carrying IOAM-Data-Fields with
-        integrity protection, in case of performance concerns in computing
-        signature and validating it, these options can be used for a subset
-        of the packets by using sampling of data to enable IOAM with
-        integrity protection.</t>
+        <t>This method MUST use an algorithm pair defined in <xref
+        target="IOAM-IP-registry"/> and the approach MUST be symmetric.</t>
       </section>
 
       <section title="Asymmetric key based signature">
@@ -679,23 +669,8 @@
         responsible for key distribution are outside the scope of this
         document.</t>
 
-        <t>This method uses the following algorithms:
-          <list style="numbers">
-            <t>The signature algorithm MUST be Elliptic Curve Digital
-            Signature Algorithm (ECDSA) with curve P-256 <xref
-            target="RFC6090"/> <xref target="DSS"/>.</t>
-
-            <t>The digest/hash algorithm MUST be SHA-256 <xref target="SHS"/>.</t>
-          </list>
-        </t>
-
-        <t>The Signature consumes 32 octets with ECDSA
-        P-256. With this method, the Signature is
-        carried only once for the entire packet. As there are dedicated
-        options for carrying IOAM-Data-Fields with integrity protection, in case of
-        performance concerns in computing signature and validating it,
-        these options can be used for a subset of the packets by using
-        sampling of data to enable IOAM with integrity protection.</t>
+        <t>This method MUST use an algorithm pair defined in <xref
+        target="IOAM-IP-registry"/> and the approach MUST be asymmetric.</t>
       </section>
     </section>
 
@@ -726,24 +701,25 @@
         IANA identify the digest algorithm and signature algorithm used in the
         Signature Suite Identifier field. IANA has registered the following
         algorithm suite identifiers for the digest algorithm and for the
-        signature algorithm. <figure>
+        signature algorithm. <figure title="IOAM Integrity Protection Algorithm
+        Suite Registry">
             <artwork>
-           IOAM Integrity Protection Algorithm Suite Registry
-
-     Algorithm    Digest       Signature    Specification
-     Suite        Algorithm    Algorithm    Pointer
-     Identifier
-   +------------+------------+-------------+-----------------------+
-   | 0x0        | Reserved   | Reserved    | This document         |
-   +------------+------------+-------------+-----------------------+
-   | 0x1        | SHA-256    | ECDSA P-256 | [SHS] [DSS] [RFC6090] |
-   |            |            |             | This document         |
-   +------------+------------+-------------+-----------------------+
-   | 0x2        | SHA-256    | AES-256     | [AES] [NIST.800-38D]  |
-   |            |            |             | This document         |
-   +------------+------------+-------------+-----------------------+
-   | 0xEF-0xFF  | Unassigned | Unassigned  |                       |
-   +------------+------------+-------------+-----------------------+
+ Algorithm
+ Suite        Digest        Signature    Specification
+ Identifier   Algorithm     Algorithm    Pointer           Approach
++-----------+------------+-------------+----------------+------------+
+| 0x00      | Reserved   | Reserved    | This document  |    None    |
++-----------+------------+-------------+----------------+------------+
+| 0x01      | SHA-256    | ECDSA P-256 | [SHS] [DSS]    | Asymmetric |
+|           |            |             | [RFC6090]      |            |
+|           |            |             | This document  |            |
++-----------+------------+-------------+----------------+------------+
+| 0x02      | SHA-256    | AES-256     | [AES]          | Symmetric  |
+|           |            |             | [NIST.800-38D] |            |
+|           |            |             | This document  |            |
++-----------+------------+-------------+----------------+------------+
+| 0x03-0xFF | Unassigned | Unassigned  |                |            |
++-----------+------------+-------------+----------------+------------+
       </artwork>
           </figure> Future assignments are to be made using the Standards
         Action process defined in <xref target="RFC8126"/>. Assignments

--- a/drafts/draft-ietf-ippm-ioam-data-integrity.xml
+++ b/drafts/draft-ietf-ippm-ioam-data-integrity.xml
@@ -241,40 +241,39 @@
       <t>The current <xref target="I-D.ietf-ippm-ioam-data"/> assumes that
       IOAM is deployed in limited domains, where an operator has
       means to select, monitor, and control the access to all the networking
-      devices, making the domain a trusted network. As such, IOAM tracing data
-      is carried in the packets in clear and there are no protections against
+      devices, making the domain a trusted network. As such, IOAM data fields
+      are carried in clear within packets and there are no protections against
       any node or middlebox tampering with the data. 
-      IOAM tracing data collected in an untrusted or semi-trusted environment 
-      requires integrity protection to support critical operational decisions.
+      IOAM data fields collected in an untrusted or semi-trusted environment
+      require integrity protection to support critical operational decisions.
       </t>
 
       <t>The following considerations and
       requirements are to be taken into account in addition to addressing the
-      problem of detectability of any integrity breach of the IOAM trace data
+      problem of detectability of any integrity breach of the IOAM data fields
       collected: <list style="numbers">
-          <t>IOAM trace data is processed by the data plane, hence viability
-          of any method to prove integrity of the IOAM trace data must be
-          feasible at data plane processing/forwarding rates (IOAM data might
+          <t>IOAM data is processed by the data plane, hence viability
+          of any method to prove integrity of the IOAM data fields must be
+          feasible at data plane processing/forwarding rates (IOAM might
           be applied to all traffic a router forwards).</t>
 
-          <t>IOAM trace data is carried within data packets. Additional space
-          required to prove integrity of the data needs to be optimal, i.e.
+          <t>IOAM data is carried within packets. Additional space
+          required to prove integrity of the IOAM data fields needs to be optimal, i.e.
           should not exceed the MTU or have adverse effect on packet
           processing.</t>
 
-          <t>Replay protection of older IOAM trace data should be possible.
+          <t>Replay protection of older IOAM data should be possible.
           Without replay protection, a rogue node can present the old IOAM
-          trace data, masking any ongoing network issues/activity and making the
-          IOAM trace data collection useless.</t>
+          data, masking any ongoing network issues/activity and making the
+          IOAM data fields collection useless.</t>
 
       </list></t>
 
       <t>This document defines the methods to protect the integrity of IOAM
-	      data fields, using the IOAM Trace Option-Types 
+	      data fields, using the IOAM Option-Types
 	      specified in <xref target="I-D.ietf-ippm-ioam-data"/>
-	      as example. The methods similarily apply to
-		      other IOAM Option-Types such as the DEX Option-Type
-	      <xref target="I-D.ietf-ippm-ioam-direct-export"/>.</t>
+	      as an example. The methods similarily apply to
+		      other IOAM Option-Types with data fields.</t>
     </section>
 
     <section anchor="Conventions" title="Conventions">
@@ -354,7 +353,8 @@
         <t>Threat <list hangIndent="10" style="empty">
             <t>An on-path attacker can modify the header in IOAM Option-Types
             in order to change or disrupt the
-            behavior of nodes processing IOAM data fields along the path.</t>
+            behavior of nodes processing IOAM data fields along the path. This
+            threat is not within the scope of this document.</t>
           </list></t>
 
         <t>Impact <list hangIndent="10" style="empty">
@@ -387,28 +387,12 @@
             <t>An attacker can inject packets with IOAM Option-Type headers,
             thus manipulating other nodes that process IOAM data fields in the
             network. This threat is applicable to both on-path and off-path
-            attackers.</t>
+            attackers. This threat is not within the scope of this document.</t>
           </list></t>
 
         <t>Impact <list hangIndent="10" style="empty">
             <t>This attack and its impacts are similar to <xref
             target="ModifHeaderSec"/>.</t>
-          </list></t>
-      </section>
-
-      <section title="Replay">
-        <t>Threat <list hangIndent="10" style="empty">
-            <t>An attacker can replay packets with IOAM data fields.
-            Specifically, an attacker may replay a previously transmitted IOAM
-            Option-Type with a new data packet, thus attaching old IOAM data
-            fields to a fresh user packet. This threat is applicable to both
-            on-path and off-path attackers.</t>
-          </list></t>
-
-        <t>Impact <list hangIndent="10" style="empty">
-            <t>As with previous threats, this threat may create a false image
-            of a nonexistent failure, or may overload nodes which process IOAM
-            data fields with unnecessary processing.</t>
           </list></t>
       </section>
 
@@ -471,13 +455,11 @@
 +-------------------------------------------+--------+------------+
 |Modification: IOAM Data Fields             |   +    |            |
 +-------------------------------------------+--------+------------+
-|Modification: IOAM Option-Type Headers     |   +    |            |
+|Modification: IOAM Option-Type Headers     |        |     +      |
 +-------------------------------------------+--------+------------+
 |Injection: IOAM Data Fields                |   +    |            |
 +-------------------------------------------+--------+------------+
-|Injection: IOAM Option-Type Headers        |   +    |            |
-+-------------------------------------------+--------+------------+
-|Replay                                     |   +    |            |
+|Injection: IOAM Option-Type Headers        |        |     +      |
 +-------------------------------------------+--------+------------+
 |Management and Exporting                   |        |     +      |
 +-------------------------------------------+--------+------------+
@@ -488,84 +470,74 @@
       </section>
     </section>
 
-    <section title="Methods of providing integrity to IOAM data fields">
-      <t>This section specifies additional IOAM Option-Types to carry
-      data fields to provide for integrity protection. Methods for
-      integrity protection can leverage symmetric or
-      asymmetric key based signatures as described in the subsections below.</t>
-
-      <section anchor="IP_Options" title="Integrity Protected IOAM Option-Types">
-        <t>Each of the IOAM Option-Types defined in <xref
-        target="I-D.ietf-ippm-ioam-data"/> are extended to include Integrity
-        Protected (IP) IOAM Option-Types by allocating the following IOAM Option-Types
-        in the IOAM Option-Type registry.</t>
+    <section title="Integrity Protected Option-Types">
+    <t>This section defines new IOAM Option-Types to be allocated in the IOAM
+    Option-Type Registry. Their purpose is to carry IOAM data fields with
+    integrity protection. Each of the IOAM Option-Types defined in <xref
+    target="I-D.ietf-ippm-ioam-data"/> is extended as follows:</t>
 
         <t><list style="hanging">
             <t hangText="64">IOAM Pre-allocated Trace Integrity Protected
-            Option-Type corresponds to IOAM Pre-allocated Trace Option-Type
+            Option-Type: corresponds to the IOAM Pre-allocated Trace Option-Type
             with integrity protection.</t>
 
             <t hangText="65">IOAM Incremental Trace Integrity Protected
-            Option-Type corresponds to IOAM Incremental Trace Option-Type with
-            integrity protection.</t>
+            Option-Type: corresponds to the IOAM Incremental Trace Option-Type
+            with integrity protection.</t>
 
-            <t hangText="66">IOAM POT Integrity Protected Option-Type
-            corresponds to IOAM POT Option-Type with integrity protection.</t>
+            <t hangText="66">IOAM POT Integrity Protected Option-Type:
+            corresponds to the IOAM POT Option-Type with integrity protection.</t>
 
-            <t hangText="67">IOAM E2E Integrity Protected Option-Type
-            corresponds to IOAM E2E Option-Type with integrity protection.</t>
+            <t hangText="67">IOAM E2E Integrity Protected Option-Type:
+            corresponds to the IOAM E2E Option-Type with integrity protection.</t>
           </list></t>
-      </section>
 
-      <section anchor="IP_Subheader"
-               title="Subheader for Integrity Protected IOAM Option-Types">
+      <t>The Integrity Protection subheader follows the IOAM Option-Type
+      header when the IOAM Option-Type is an Integrity Protected Option-Type.
+      It is defined as follows:</t>
 
-        <t>An integrity subheader is used in IOAM
-        Integrity Protected Option-Types. It is defined as follows:</t>
-
-        <t><figure>
+      <t><figure>
             <artwork>
 
-    0                   1                   2                   3
-    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-   |Signature-suite|  Nonce length |           Reserved            |
-   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-   |                             Nonce                             ~
-   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-   |                           Signature                           ~
-   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ 0                   1                   2                   3
+ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|Signature-suite|  Nonce length |           Reserved            |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                             Nonce                             ~
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                           Signature                           ~
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 
 
 </artwork>
           </figure></t>
 
-        <t><list style="hanging">
-            <t hangText="Signature-suite:">8-bit unsigned integer. 
-            This field defines the algorithms used to compute the digest 
-            and the signature over the Option-Type header and data fields excluding 
-            the Signature field.</t>
+      <t><list style="hanging">
+        <t hangText="Signature-suite:">8-bit unsigned integer. 
+        This field defines the algorithms used to compute the digest 
+        and the signature over the Option-Type data fields.</t>
 
-            <t hangText="Nonce length:">8-bit unsigned integer. This field
-            specifies the length of the Nonce field in octets.</t>
+        <t hangText="Nonce length:">8-bit unsigned integer. This field
+        specifies the length of the Nonce in octets.</t>
 
-            <t hangText="Reserved:">16-bit Reserved field. MUST be set to zero
-            upon transmission and ignored upon receipt.</t>
+        <t hangText="Reserved:">16-bit Reserved field. MUST be set to zero
+        upon transmission and ignored upon receipt.</t>
 
-            <t hangText="Nonce:"> Variable length field with length specified
-            in Nonce length.</t>
+        <t hangText="Nonce:"> Variable length field with length specified
+        in Nonce length.</t>
 
-            <t hangText="Signature:"> Digital signature value generated
-            by the method and algorithm specified by Signature-suite.</t>
-          </list></t>
+        <t hangText="Signature:"> Digital signature value generated
+        by the method and algorithm specified by Signature-suite.</t>
+      </list></t>
 
-        <t>The Integrity subheader follows the IOAM Option-Type header when
-        the IOAM Option-Type is an Integrity Protected Option-Type. Pre-allocated and
-        incremental Trace Option-Type headers are as defined in <xref
-        target="I-D.ietf-ippm-ioam-data"/>. When the IOAM Option-Type is set to
-        the IOAM Pre-allocated Trace Integrity Protected Option-Type or IOAM
-        Incremental Trace Integrity Protected Option-Type, then the Integrity
-        Protection subheader follows the original IOAM Option-Type header:
+      <section title="Integrity Protected Trace Option-Types">
+        <t>Both the IOAM Pre-allocated Trace Option-Type header and the IOAM
+        Incremental Trace Option-Type header, as defined in <xref
+        target="I-D.ietf-ippm-ioam-data"/>, are followed by the Integrity
+        Protection subheader when the IOAM Option-Type is respectively set to
+        the IOAM Pre-allocated Trace Integrity Protected Option-Type or the IOAM
+        Incremental Trace Integrity Protected Option-Type:
         <figure>
             <artwork>
  0                   1                   2                   3
@@ -584,7 +556,9 @@
 
 </artwork>
           </figure></t>
+      </section>
 
+      <section title="Integrity Protected POT Option-Type">
         <t>The IOAM POT Option-Type header, as defined in <xref
         target="I-D.ietf-ippm-ioam-data"/>, is followed by the Integrity
         Protection subheader when the IOAM Option-Type is set to the IOAM POT
@@ -604,7 +578,9 @@
 
 </artwork>
           </figure></t>
+      </section>
 
+      <section title="Integrity Protected E2E Option-Type">
         <t>The IOAM E2E Option-Type header, as defined in <xref
         target="I-D.ietf-ippm-ioam-data"/>, is followed by the Integrity
         Protection subheader when the IOAM Option-Type is set to the IOAM E2E
@@ -625,109 +601,109 @@
 </artwork>
           </figure></t>
       </section>
+    </section>
 
-      <section title="Space optimized symmetric key based signing of IOAM data">
+    <section title="Methods for integrity protection">
+      <t>Methods for integrity protection can leverage symmetric or asymmetric
+      key based signatures, as described in the subsections below. Both methods
+      work as follows:
+
+        <list style="numbers">
+          <t>The encapsulating node creates a nonce and stores it in the Nonce
+          field of the Integrity Protection subheader. The signature is
+          generated over the Nonce field and the hash of data fields it has
+          inserted, i.e., sign(Nonce || hash(data fields)). Data fields that
+          will be updated in-place MUST be excluded from the signature (e.g.,
+          the POT Cumulative field). The signature is stored in the Signature
+          field of the Integrity Protection subheader. Important note: if all
+          the inserted data fields will be updated in-place, or if there is no
+          data field at all, the encapsulating node MUST NOT use an Integrity
+          Protected Option-Type.</t>
+
+          <t>A transit node generates a signature over the Signature field and
+          the hash of data fields it has inserted, i.e.,
+          sign(Signature || hash(data fields)). Data fields that are updated
+          in-place MUST be excluded from the signature (e.g., the POT Cumulative
+          field). The signature is stored in the Signature field of the
+          Integrity Protection subheader. Important note: if all the data fields
+          involved are updated in-place, or if there is no data field involved,
+          the transit node MUST NOT generate a signature and MUST NOT update the
+          Signature field.</t>
+
+          <t>The decapsulating node behaves exactly the same as a transit node.
+          The only difference is that the signature MAY NOT be required when the
+          decapsulating node is also the Validator, for obvious performance
+          reasons.</t>
+
+          <t>The Validator recreates the signature over data fields collected
+          and checks the integrity against the Signature field. In order to
+          recompute the signature, the Validator iteratively follows the same
+          procedure as for the encapsulating, transit and decapsulating nodes,
+          in that order. It is trivial in some cases (e.g., POT Type-0 or E2E),
+          where only the encapsulating node generates a signature. For other
+          cases where transit nodes also generate a signature (e.g., Trace
+          Option-Types), node-ids MUST be recorded. Details on how the mapping
+          between node-ids and keys is implemented are outside the scope of this
+          document.</t>
+        </list>
+      </t>
+
+      <section title="Symmetric key based signature">
         <t>This method assumes that symmetric keys have been distributed to
         the respective nodes as well as the Validator (the Validator receives
-        all the keys). The details of the mechanisms of how keys are
-        distributed are outside the scope of this document. The
-        "Signature" field is populated as follows: <list style="numbers">
-            <t>The first node creates a nonce and signature over the hash of
-            IOAM Option excluding the Signature field, the nonce and its
-            symmetric key. The nonce is included as a field in Integrity
-            Protection subheader of the corresponding IOAM Option. The
-            resulting signature is included in the corresponding Signature
-            field.</t>
+        all the keys). The details of the mechanisms responsible for key
+        distribution are outside the scope of this document.</t>
 
-            <t>Transit nodes will update the Signature field by creating
-            a signature of data where the data is [Signature ||
-            hash(node_data_list[x])] with its symmetric key in case of IOAM
-            Trace Integrity Protected Options. Transit nodes updating
-            IOAM POT Option will update the Signature field by creating a
-            signature of data where the data is [Signature || hash(IOAM POT
-            OPTION excluding Signature field)] with its symmetric key in case
-            of IOAM POT Integrity Protected Option.</t>
+        <t>This method uses the following algorithms:
+          <list style="numbers">
+            <t>The signature algorithm MUST be Advanced Encryption Standard
+            (AES) AES-256. <xref target="AES"/> <xref target="NIST.800-38D"/>.</t>
 
-            <t>The Validator will iteratively recreate the Signature over the
-            IOAM Option fields collected and matches the Signature field to
-            validate the data integrity.</t>
-          </list></t>
+            <t>The digest/hash algorithm MUST be SHA-256 <xref target="SHS"/>.</t>
+          </list>
+        </t>
 
-        <t>This method uses the following algorithms: <list
-            style="numbers">
-            <t>The algorithm to calculate the signature using symmetric key MUST
-            be Advanced Encryption Standard (AES) AES-256. <xref
-            target="AES"/> <xref target="NIST.800-38D"/>.</t>
-
-            <t>The digest/hash algorithm used MUST be SHA-256 <xref
-            target="SHS"/>.</t>
-          </list></t>
-
-        <section title="Overhead consideration">
-          <t>The Signature would consume 32 bytes with AES-256. With
-          this method the Signature is carried only once for the entire
-          packet. As there are dedicated options for carrying IOAM data with
-          integrity protection, in case of performance concerns in calculating
-          signature and validating it, these options can be used for a subset
-          of the packets by using sampling of data to enable IOAM with
-          integrity protection.</t>
-        </section>
+        <t>The Signature consumes 32 octets with AES-256. With
+        this method, the Signature is carried only once for the entire
+        packet. As there are dedicated options for carrying IOAM data with
+        integrity protection, in case of performance concerns in computing
+        signature and validating it, these options can be used for a subset
+        of the packets by using sampling of data to enable IOAM with
+        integrity protection.</t>
       </section>
 
-      <section title="Space optimized asymmetric key based signing of trace data">
+      <section title="Asymmetric key based signature">
         <t>This method assumes that asymmetric keys have been generated per
-        IOAM node and the respective nodes can access their keys. The
-        Validator receives all the public keys. The details of the mechanisms
-        of how keys are generated and shared are outside the scope of this
-        document. The " Signature" field is populated as follows:<list
-            style="numbers">
-            <t>The first node creates a nonce and signs over the hash of IOAM
-            Option it populates excluding the Signature field in the option,
-            the nonce and its private key. The resulting signature is included
-            in the Signature field.</t>
+        IOAM node and the respective nodes can access their keys (the
+        Validator receives all the public keys). The details of the mechanisms
+        responsible for key distribution are outside the scope of this
+        document.</t>
 
-            <t>Transit nodes will update the Signature field by creating
-            a signature of data where the data is [Signature ||
-            hash(node_data_list[x])] with its private key in case of IOAM
-            Trace Integrity Protected Options. Transit nodes updating
-            IOAM POT Option will update the Signature field by creating a
-            signature of data where the data is [Signature || hash(IOAM POT
-            OPTION excluding Signature field)] with its private key in case of
-            IOAM POT Integrity Protected Option.</t>
-
-            <t>The Validator will iteratively recreate the Signature over the
-            IOAM Option fields collected and matches the Signature field to
-            validate the data integrity using public keys of the IOAM
-            nodes.</t>
-          </list></t>
-
-        <t>This method uses the following algorithms: <list
-            style="numbers">
-            <t>The signature algorithm used MUST be the Elliptic Curve Digital
+        <t>This method uses the following algorithms:
+          <list style="numbers">
+            <t>The signature algorithm MUST be Elliptic Curve Digital
             Signature Algorithm (ECDSA) with curve P-256 <xref
             target="RFC6090"/> <xref target="DSS"/>.</t>
 
-            <t>The digest/hash algorithm used MUST be SHA-256 <xref
-            target="SHS"/>.</t>
-          </list></t>
+            <t>The digest/hash algorithm MUST be SHA-256 <xref target="SHS"/>.</t>
+          </list>
+        </t>
 
-        <section title="Overhead consideration">
-          <t>The Signature consumes 32 bytes based on the SHA-256 ECDSA
-          P-256 algorithm employed. With this method the Signature is
-          only carried once for the entire packet. As there are dedicated
-          options for carrying IOAM data with integrity protection, in case of
-          performance concerns in calculating signature and validating it,
-          these options can be used for a subset of the packets by using
-          sampling of data to enable IOAM with integrity protection.</t>
-        </section>
+        <t>The Signature consumes 32 octets with ECDSA
+        P-256. With this method, the Signature is
+        carried only once for the entire packet. As there are dedicated
+        options for carrying IOAM data with integrity protection, in case of
+        performance concerns in computing signature and validating it,
+        these options can be used for a subset of the packets by using
+        sampling of data to enable IOAM with integrity protection.</t>
       </section>
     </section>
 
     <section anchor="IANA" title="IANA Considerations">
 
       <section anchor="IOAM-type-registry" title="IOAM Option-Type Registry">
-        <t>The following code points are defined in this draft in "IOAM
-        Option-Type Registry" :</t>
+        <t>This draft defines the following new code points in the IOAM
+        Option-Type Registry:</t>
 
         <t><list style="hanging">
             <t hangText="64">IOAM Pre-allocated Trace Integrity Protected
@@ -777,8 +753,14 @@
     </section>
 
     <section anchor="Security" title="Security Considerations">
-      <t>This section will be completed in a future revision of this
-      document.</t>
+    <t>This section discusses additional security aspects.</t>
+
+        <section title="Replay protection">
+        <t>The nonce makes a signature chain unique but does not necessarily
+        prevent replay attacks. To enable replay protection, both the encap node
+        and the validator MUST synchronize on a unique nonce, e.g., based on a
+        timestamp only valid for a short period of time.</t>
+        </section>
     </section>
 
     <section title="Acknowledgements">
@@ -874,7 +856,7 @@
 
       &I-D.ietf-detnet-security;
 
-      &I-D.ietf-ippm-ioam-direct-export;
+<!--      &I-D.ietf-ippm-ioam-direct-export; -->
 
       &RFC7276;
 


### PR DESCRIPTION
Major revision of draft-ietf-ippm-ioam-data-integrity. Here is a summary
of changes:
 - integrity protection of **data fields** *only*.
 - section defining Integrity Protected Option-Types (+ integrity
protection subheader) was restructured.
 - following point 1, section defining methods was restructured and the
procedure (as generic as possible) was  updated accordingly.
 - removed DEX citation/reference (out of scope, see procedure in 3).
 - replay protection not totally in scope: moved to security section.
 - some edits here and there

Example for each Option-Type, following the new procedure defined in the
draft:
 [Trace Option-Types]
  - encap:   sign(Nonce || hash(data fields))
  - transit: sign(Signature || hash(data fields))
  - decap:   same as transit (or validator)

  -> the validator uses recorded node-ids to map ids with keys and
recreates the signature iteratively, following the same procedure in the
same order.

 [POT (Type 0) Option-Type]
  - encap:   sign(Nonce || hash(data fields minus Cumulative field))
  - transit: all data fields involved are modified in-place (Cumulative
field) -> do not sign
  - decap:   same as transit (or validator)

  -> only the encapsulating node has signed the data fields, so the
validator easily recreates the signature.

 [E2E Option-Type]
  - encap:   sign(Nonce || hash(data fields))
  - transit: none
  - decap:   no data field involved -> do not sign (or validator)

  -> only the encapsulating node has signed the data fields, so the
validator easily recreates the signature.

 [DEX Option-Type]
  - encap: does not contain any data fields -> do not use Integrity
Protected Option-Type.


Notes:
 - should we use "IOAM-Data-Fields" as defined in
draft-ietf-ippm-ioam-data or keep "data fields" as currently?
 - Validator: hard to keep it generic. Also, should we mention the
special case with Trace Option-Types and Opaque State Snapshot? Not sure
it is really that useful as implementors would figure it out obviously,
and I suspect that it would overload the paragraph. Thoughts?

Resolves inband-oam/ietf#238
Resolves inband-oam/ietf#239
Resolves inband-oam/ietf#240
Resolves inband-oam/ietf#242

Signed-off-by: Justin Iurman <justin.iurman@uliege.be>