### PR TITLE
DEX draft IESG review fixes

### DIFF
--- a/drafts/draft-ietf-ippm-ioam-direct-export.xml
+++ b/drafts/draft-ietf-ippm-ioam-direct-export.xml
@@ -178,9 +178,9 @@
       to locally aggregate and process IOAM data, and/or to export it to a
       receiving entity (or entities). Throughout the document this
       functionality is referred to as collection and/or exporting. A
-      "receiving entity" in this context can be, for example, an external
-      collector, analyzer, controller, decapsulating node, or a software
-      module in one of the IOAM nodes.</t>
+      "receiving entity" in this context is an entity
+      that resides within the IOAM domain such as a collector, analyzer, 
+	  controller, decapsulating node, or a software module in one of the IOAM nodes.</t>
 
       <t>Note that even though the IOAM-Option-Type is called "Direct Export",
       it depends on the deployment whether the receipt of a packet with DEX
@@ -189,9 +189,6 @@
       processing of OAM data. The functionality of this local processing is
       not within the scope of this document.</t>
 
-      <t>This draft has evolved from combining some of the concepts of PBT-I
-      from <xref target="I-D.song-ippm-postcard-based-telemetry"/> with
-      immediate exporting from <xref target="I-D.ietf-ippm-ioam-flags"/>.</t>
     </section>
 
     <section anchor="Conventions" title="Conventions">
@@ -315,14 +312,15 @@ packets   |Encapsu-|     | Transit|     | Transit|     |Decapsu-|
           encapsulating node. In this context N is a parameter that can be
           configurable by network operators. If there is an upper bound, M, on
           the number of IOAM transit nodes in any path in the network, then it
-          is recommended to use an N such that N &gt;&gt; M. The rationale is
+          is RECOMMENDED to use an N such that N &gt;&gt; M (N is much greater
+		  than M). The rationale is
           that a packet that includes a DEX Option-Type may trigger an
           exported packet from each IOAM transit node along the path for a
           total of M exported packets. Thus, if N &gt;&gt; M then the number
           of exported packets is significantly lower than the number of data
           packets forwarded by the IOAM encapsulating node. If there is no
           prior knowledge about the network topology or size, it is
-          recommended to use N&gt;100.</t>
+          RECOMMENDED to use N&gt;100.</t>
         </section>
 
         <section anchor="ExportSec" title="Responding to the DEX Trigger">
@@ -342,14 +340,15 @@ packets   |Encapsu-|     | Transit|     | Transit|     |Decapsu-|
           packets is significantly lower than the number of packets that are
           forwarded by the device. The exported data rate SHOULD NOT exceed
           1/N of the interface capacity on any of the IOAM node's interfaces.
-          It is recommended to use N&gt;100. Depending on the IOAM node's
+          It is RECOMMENDED to use N&gt;100. Depending on the IOAM node's
           architecture considerations, the export rate may be limited to a
           lower number in order to avoid loading the IOAM node. An IOAM node
           MAY maintain a counter or a set of counters that count the events in
           which the IOAM node receives a packet with the DEX Option-Type and
           does not collect and/or export data due to the rate limits.</t>
 
-          <t>Exported packets SHOULD NOT be exported over a path or a tunnel
+          <t>IOAM nodes SHOULD NOT be configured to export packets
+		  over a path or a tunnel
           that is subject to IOAM direct exporting. Furthermore, IOAM
           encapsulating nodes that can identify a packet as an IOAM exported
           packet MUST NOT push a DEX Option-Type into such a packet. This
@@ -361,7 +360,7 @@ packets   |Encapsu-|     | Transit|     | Transit|     |Decapsu-|
           target="RFC9197"/>), and specifically nodes that do not support the
           DEX Option-Type ignore it. Note that as per <xref target="RFC9197"/>
           a decapsulating node removes the IOAM encapsulation and all its
-          IOAM-Option-Types, and specifically in the case where one of these
+          IOAM-Option-Types. Specifically, this applies to the case where one of these
           options is a (possibly unknown) DEX Option-Type. The ability to skip
           over a (possibly unknown) DEX Option-Type in the parsing or in the
           decapsulation procedure is dependent on the specific encapsulation,
@@ -431,12 +430,13 @@ packets   |Encapsu-|     | Transit|     | Transit|     |Decapsu-|
             that the Checksum Complement is intended for in-flight packet
             modifications and is not relevant for direct exporting.</t>
 
-            <t hangText="Reserved">This field SHOULD be ignored by the
+            <t hangText="Reserved">This field MUST be ignored by the
             receiver.</t>
 
             <t hangText="Optional fields">The optional fields, if present,
             reside after the Reserved field. The order of the optional fields
-            is according to the respective bits that are enabled in the
+            is according to the order of the respective bits, starting from
+			the most significant bit, that are enabled in the
             Extension-Flags field. Each optional field is 4 octets long.</t>
 
             <t hangText="Flow ID">An optional 32-bit field representing the
@@ -446,14 +446,15 @@ packets   |Encapsu-|     | Transit|     | Transit|     |Decapsu-|
             exported data of the same flow from multiple nodes and from
             multiple packets. Flow ID values are expected to be allocated in a
             way that avoids collisions. For example, random assignment of Flow
-            ID values can be subject to birthday problem conflicts, while
+            ID values can be subject to collisions, while
             centralized allocation can avoid this problem. The specification
             of the Flow ID allocation method is not within the scope of this
             document.</t>
 
             <t hangText="Sequence Number">An optional 32-bit sequence number
-            starting from 0 and increasing by 1 for each following monitored
-            packet from the same flow at the encapsulating node. The Sequence
+            starting from 0 and incremented by 1 for each 
+            packet from the same flow at the encapsulating node that includes
+			the DEX option. The Sequence
             Number, when combined with the Flow ID, provides a convenient
             approach to correlate the exported data from the same user
             packet.</t>
@@ -463,22 +464,24 @@ packets   |Encapsu-|     | Transit|     | Transit|     |Decapsu-|
 
     <section anchor="IANA" title="IANA Considerations">
       <section anchor="IANAtype" title="IOAM Type">
-        <t>The "IOAM Type Registry" was defined in Section 7.2 of <xref
+        <t>The "IOAM Option-Type Registry" was defined in Section 7.1 of <xref
         target="RFC9197"/>. IANA is requested to allocate the following code
-        point from the "IOAM Type Registry" as follows:</t>
+        point from the "IOAM Option-Type Registry" as follows:</t>
 
         <t><list hangIndent="11" style="hanging">
             <t hangText="TBD-type">IOAM Direct Export (DEX) Option-Type</t>
           </list></t>
 
         <t>If possible, IANA is requested to allocate code point 4
-        (TBD-type).</t>
+        (TBD-type). The "Description" for the new option should be 
+		"Direct exporting" and the "Reference" should be the current document.
+		</t>
       </section>
 
       <section anchor="IANAflags" title="IOAM DEX Flags">
         <t>IANA is requested to define an "IOAM DEX Flags" registry. This
-        registry includes 8 flag bits. Allocation is based on the "RFC
-        Required" procedure, as defined in <xref target="RFC8126"/>.</t>
+        registry includes 8 flag bits. Allocation is based on the "IETF
+        Review" procedure, as defined in <xref target="RFC8126"/>.</t>
 
         <t>New registration requests MUST use the following template:</t>
 
@@ -499,7 +502,7 @@ packets   |Encapsu-|     | Transit|     | Transit|     |Decapsu-|
         This registry includes 8 flag bits. Bit 0 (the most significant bit)
         and bit 1 in the registry are allocated by this document, and
         described in <xref target="OptionSec"/>. Allocation of the other bits
-        should be performed based on the "RFC Required" procedure, as defined
+        should be performed based on the "IETF Review" procedure, as defined
         in <xref target="RFC8126"/>.</t>
 
         <t><list style="hanging">
@@ -595,8 +598,10 @@ packets   |Encapsu-|     | Transit|     | Transit|     |Decapsu-|
       <t>Although the exporting method is not within the scope of this
       document, any exporting method MUST secure the exported data from the
       IOAM node to the receiving entity. Specifically, an IOAM node that
-      performs DEX exporting MUST send the exported data to a pre- configured
-      trusted receiving entity. Furthermore, an IOAM node MUST gain explicit
+      performs DEX exporting MUST send the exported data to a pre-configured
+      trusted receiving entity that is in the same IOAM domain as the exporting
+	  IOAM node. 
+	  Furthermore, an IOAM node MUST gain explicit
       consent to export data to a receiving entity before starting to send
       exported data.</t>
 
@@ -636,10 +641,6 @@ packets   |Encapsu-|     | Transit|     | Transit|     |Decapsu-|
 
       &RFC8174;
 
-      &RFC5475;
-
-      &RFC7014;
-
       &RFC9197;
     </references>
 
@@ -647,6 +648,10 @@ packets   |Encapsu-|     | Transit|     | Transit|     |Decapsu-|
       &RFC6291;
 
       &RFC8126;
+
+      &RFC5475;
+
+      &RFC7014;
 
       &I-D.spiegel-ippm-ioam-rawexport;
 
@@ -659,15 +664,19 @@ packets   |Encapsu-|     | Transit|     | Transit|     |Decapsu-|
       &I-D.ietf-ippm-ioam-ipv6-options;
     </references>
 
-    <section anchor="appendix" title="Hop Limit in Direct Exporting">
-      <t>In order to help correlate and order the exported packets, it is
+    <section anchor="appendix" title="Notes About the History of this Document">
+      <t>This document evolved from combining some of the concepts of PBT-I
+      from <xref target="I-D.song-ippm-postcard-based-telemetry"/> with
+      immediate exporting from early versions of 
+	  <xref target="I-D.ietf-ippm-ioam-flags"/>.</t>
+
+ 	 <t>In order to help correlate and order the exported packets, it is
       possible to include the Hop_Lim/Node_ID IOAM-Data-Field in exported
       packets; if the IOAM-Trace-Type <xref target="RFC9197"/> has the
       Hop_Lim/Node_ID bit set, then exported packets include the
       Hop_Lim/Node_ID IOAM-Data-Field, which contains the TTL/Hop Limit value
-      from a lower layer protocol.</t>
-
-      <t>An alternative approach was considered during the design of this
+      from a lower layer protocol.
+      An alternative approach was considered during the design of this
       document, according to which a 1-octet Hop Count field would be included
       in the DEX header (presumably by claiming some space from the Flags
       field). The Hop Limit would starts from 0 at the encapsulating node and


### PR DESCRIPTION
The IESG comments can be found below, with my responses and text fixes marked [TM].


Murray Kucherawy
Discuss
Discuss (2022-06-30)
In Section 3.2, there's this field definition:

   Reserved        This field SHOULD be ignored by the receiver.

I'm worried about interoperability here.  "SHOULD" allows a choice.  As written, I would be within the protocol if I decided to interpret this field, even if the other participants put junk here.  Wouldn't it be better to say this is a "MUST", or require that it be all zero bits (at least in this version)?  If you really think this needs to be a "SHOULD", I suggest explaining the choice that's being made available to an implementer here.

[TM] Fixed to MUST.


Comment (2022-06-30)
Thank you to the Working Group for tackling the issue of the author count.  I know those conversations can be quite un-fun.

I concur with John that the references to RFCs 7014 and 5475 should be informative.

Section 4.1 needs a bit of work.  It claims that Section 7.2 of RFC9197 created to the "IOAM Type Registry", but it's actually the "IOAM Trace-Type Registry", yet you appear to want to register stuff in the "IOAM Option-Type Registry" which would be Section 7.1 of RFC 9197.  Please clarify.  Also, both of those registries require that the "Reference" column be specified explicitly, even though it's fairly obvious what it's going to be.

[TM] Fixed.



Robert Wilton
Discuss

Discuss (2022-06-30)
Hi,

I had a couple of minor discuss comments to clarify a couple of points that seemed unclear:

1) Definition of Sequence Number:

   Sequence Number An optional 32-bit sequence number starting from 0
                   and increasing by 1 for each following monitored
                   packet from the same flow at the encapsulating node.
                   The Sequence Number, when combined with the Flow ID,
                   provides a convenient approach to correlate the
                   exported data from the same user packet.

Please can you clarify.  Is this every packet in the flow (presumably not)?  Does monitored packet means just those with the DEX option?  Could it include other packets 

[TM] Text updated - only packets with the DEX option.

2. Optional field ordering.
   Optional fields The optional fields, if present, reside after the
                   Reserved field.  The order of the optional fields is
                   according to the respective bits that are enabled in
                   the Extension-Flags field.  Each optional field is 4
                   octets long.

Please can clarify that the order is from most significant bit to least significant bit of the option field.

[TM] Fixed.

3. Allocation is based on the "RFC
   Required" procedure, as defined in [RFC8126].

Given the number of extensions is so limited, is RFC required (e.g. allows ISE) really a strict enough allocation policy?

[TM] Changed to "IETF Review"


Comment (2022-06-30)
Here are my non-blocking comments:

1.
   This draft has evolved from combining some of the concepts of PBT-I
   from [I-D.song-ippm-postcard-based-telemetry] with immediate
   exporting from [I-D.ietf-ippm-ioam-flags].

I'm not sure that this paragraph is really helpful now, and could probably be deleted - you could use the datatracker to indicate the document history and which previous drafts this document replaces.

[TM] Moved this sentence to the appendix.

2.
   N >> M

I'm assuming that by ">>", this means much greater than?  It would be better use words here, or at least define what this means (e.g., as opposed to a bit-shift).

[TM] Added an explanation.

3. 
   An IOAM node
   MAY maintain a counter or a set of counters that count the events in
   which the IOAM node receives a packet with the DEX Option-Type and
   does not collect and/or export data due to the rate limits.

Given that this is a MAY, I wasn't sure that this really specifies anything, I guess that it is just offering a suggestion. 

[TM] Right, suggest to leave as-is.

4.
   Exported packets SHOULD NOT be exported over a path or a tunnel that
   is subject to IOAM direct exporting.  Furthermore, IOAM encapsulating
   nodes that can identify a packet as an IOAM exported packet MUST NOT
   push a DEX Option-Type into such a packet.  This requirement is
   intended to prevent nested exporting and/or exporting loops.
   
It was unclear to me how that that SHOULD NOT can really be enforced, if the exported packets are allowed to leave the limited domain.  Perhaps the "SHOULD NOT" should be limited to the domain where IOAM is operating?

[TM] Rephrased. "IOAM nodes SHOULD NOT be configured to export packets..."

5.
   transit or decapsulating IOAM node that receives an unknown IOAM-
   Option-Type ignores it (as defined in [RFC9197]), and specifically
   nodes that do not support the DEX Option-Type ignore it.  Note that
   as per [RFC9197] a decapsulating node removes the IOAM encapsulation
   and all its IOAM-Option-Types, and specifically in the case where one
   of these options is a (possibly unknown) DEX Option-Type.  The
   ability to skip over a (possibly unknown) DEX Option-Type in the
   parsing or in the decapsulation procedure is dependent on the
   specific encapsulation, which is outside the scope of this document.
   For example, when IOAM is encapsulated in IPv6

I found the sentence from "Note that ..." to be somewhat unclear.

[TM] Rephrased.


6. Option-Type Format

Would it be more helpful to explicitly specify what the length is.  I.e., X bytes + 4 * number of set bits in the Extension-Flags?

7. Extension-Flags

More a question for my own knowledge:  I presume that the length calculation (i.e., checking for the count of set bits) can be performed efficiently?  I.e., if calculating the length is important on any fast path.

8. subject to birthday problem conflicts, while centralized

Would it be helpful to spell out what is meant by "birthday problem conflicts", or perhaps include an informative reference to the wiki page?

[TM] Rephrased.

Nits:
N>100 => N > 100


Roman Danyliw
Discuss
Discuss (2022-06-29)

It isn’t clear whether DEX can be exported outside of the IOAM domain.  If it can, more is needed to describe the implications.  There are the following related statements:

(a) Section 3.1.2 says:
   Exported packets SHOULD NOT be exported over a path or a tunnel that
   is subject to IOAM direct exporting.

(b) Section 6 says:
   IOAM is assumed to be deployed in a restricted administrative domain,
   thus limiting the scope of the threats above and their affect.  This
   is a fundamental assumption with respect to the security aspects of
   IOAM, as further discussed in [RFC9197].
   
(c) Section 6 says:
   Although the exporting method is not within the scope of this
   document, any exporting method MUST secure the exported data from the
   IOAM node to the receiving entity.  Specifically, an IOAM node that
   performs DEX exporting MUST send the exported data to a pre-
   configured trusted receiving entity.  Furthermore, an IOAM node MUST
   gain explicit consent to export data to a receiving entity before
   starting to send exported data.

Statement (b) is the usual caveat that IOAM traffic stays inside the domain.  However, this new option type is something different – there are the packets themselves and the telemetry generated from them (i.e., the export packets).  Statement (c) is clear and helpful but doesn’t resolve if these entities are in the IOAM domain.  Statement (a) seems to mitigation for not creating loops but like (c) silent on clarifying whether in the IOAM domain.

If export can only happen in the IOAM domain, consider adding something as simple as the following in the Security Considerations:

NEW:
DEX exporting MUST NOT be to entities outside of the IOAM domain.


[TM] Rephrased the following sentence:
OLD:
Specifically, an IOAM node that
performs DEX exporting MUST send the exported data to a pre-configured
trusted receiving entity.
NEW:
Specifically, an IOAM node that
performs DEX exporting MUST send the exported data to a pre-configured
trusted receiving entity that is in the same IOAM domain as the exporting
IOAM node.


Comment (2022-06-29)
Thank you to Stephen Farrell for the SECDIR review.

Zaheduzzaman Sarker
Discuss
Discuss (2022-06-29)
Thanks for working on this specification. 

Thanks to Colin Perkins for his valuable TSVART review. I find the TSVART early reviewer's concern on rate limiting the exported traffic triggered by DEX Option-type as only protection mechanism (https://mailarchive.ietf.org/arch/msg/tsv-art/1WNgYWGJmxLd4f3RAiDk-LJ-S8Y/) very valid but haven't seen it addressed. In this discuss, I would like to bring back attention to that concern and would like to discuss why there should not be a circuit breaker kind of functionality required here?

[TM] Here is Colin's comment:
In particular, the draft mandates that rate limiting is implemented on the
exported packets, limiting the exporting data rate to 1/N of the interface
bandwidth (where N can be configured, but defaults to 100). This limits the
amount of traffic that can be generated, but still appears to allow for a
significant amplification attack where a single injected IOAM packet can
trigger flows up to 1% of link capacity (in the default setting) from on path
routers. The provision of a rate limit is therefore important, but I’m
concerned that it’s not sufficient to prevent abuse.

[TM] The rate limit is just one component of the security measures here. There was a long discussion in the IPPM working group about amplification attacks and what we came up with in order to mitigate these attacks is a combination of the following:
- Rate limiting (1/N) at the encap node.
- Export traffic rate limiting (1/N) at the exporting node.
- No exporting over DEX-enabled tunnels.
- No DEX option over IOAM packets.
- Exporting within the IOAM domain only.
- Exporting over a secure connection to a trusted destination.

The discussion on the IPPM working group can be found at:
https://mailarchive.ietf.org/arch/msg/ippm/PyfokOEsBBCTtRdNYG-Vr-674Nw/
https://mailarchive.ietf.org/arch/msg/ippm/JNiX94A7fN6tUPsA-VQizQEBWms/



I also think this specification should be explicit about not exporting IOAM data to any receiver outside of IOAM limited domain. Hence supporting Roman's discuss.

for example - The introduction section can state-

OLD text-

   A
   "receiving entity" in this context can be, for example, an external
   collector, analyzer, controller, decapsulating node, or a software
   module in one of the IOAM nodes.

New text-

   A
   "receiving entity" in this context can be, for example, an external
   collector, analyzer, controller, decapsulating node, or a software
   module in one of the IOAM nodes with in IOAM limited domain.


[TM] Rephrased:
OLD:
   A
   "receiving entity" in this context can be, for example, an external
   collector, analyzer, controller, decapsulating node, or a software
   module in one of the IOAM nodes.
NEW:
   A
   "receiving entity" in this context is an entity
   that resides within the IOAM domain such as a collector, analyzer, 
   controller, decapsulating node, or a software module in one of the IOAM nodes.


Martin Duke
Yes

Alvaro Retana
No Objection

Andrew Alston
No Objection
Comment (2022-06-29)
Thanks for the work on this document.

I wish to fully support Roman's discuss, as I believe the document needs to be explicit about not exporting outside of the IOAM domain


Erik Kline
No Objection

John Scudder
No Objection

Comment (2022-06-29)
Thanks for this document. My only comment is that I don’t see why the references to RFCs 7014 and 5475 are normative, they seem informative to me.


Paul Wouters
No Objection

Comment (2022-06-29)
I support Roman's DISCUSS.


Personal pet peeve: I strongly prefer +------+----+   over +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+  as I find the latter too blinky and distracting from the actual diagram.

Éric Vyncke
No Objection

Comment (2022-06-27)
# Éric Vyncke, INT AD, comments for draft-ietf-ippm-ioam-direct-export-09
CC @evyncke

Thank you for the work put into this document. 

Please find below some non-blocking COMMENT points (but replies would be appreciated even if only for my own education).

Thanks to Bernie Volz for his internet directorate review at:
https://datatracker.ietf.org/doc/review-ietf-ippm-ioam-direct-export-09-intdir-telechat-volz-2022-06-23/ (please consider Bernie's comments as mine).

Special thanks to Tommy Pauly for the shepherd's detailed write-up including the WG consensus even if it lacks the justification of the intended status and uses an unusual templte. 

I hope that this helps to improve the document,

Regards,

-éric

## COMMENTS

### No export method specified

Just curious... why isn't IPFIX selected as the export method (or even a streaming telemetry)? The abstract says "The exporting method and format are outside the scope of this document."

[TM] Right, there is a separate document that defines IOAM exporting based on IPFIX, but it has not been adopted by the working group yet.

### Repetition in section 3.1

The sentence "The DEX Option-Type is used as a trigger to collect and/or export IOAM data" appears multiple times in this document and looks quite repetitive.

### Section 3.1

s/MAY export and/or collect/MAY export and/or MAY collect/ ? (just to be clear)

### Section 3.1.1 mandatory sampling ?

The 1st paragraph contains a "MUST" rather than a "SHOULD" making sampling a mandatory feature. Isn't this too strong ? Especially when aggregation can be done locally ?

[TM] There was extensive discussion about this in the working group, and this seems like an important component to mitigate the potential amplification threats.

### Section 3.1.1

In `it is recommended to use N>100` should "RECOMMENDED" be used ?

[TM] Fixed.

### Section 6

Should network operators also drop packets containing the DEX at their peering points ?

[TM] Sounds like a requirement that is not for DEX implementers or for DEX deployers.
