### PR TITLE
Version 11

### DIFF
--- a/drafts/draft-ietf-ippm-ioam-ipv6-options.xml
+++ b/drafts/draft-ietf-ippm-ioam-ipv6-options.xml
@@ -65,7 +65,7 @@
 
 
 
-    <date day="21" month="April" year="2023"/>
+    <date day="4" month="May" year="2023"/>
 
     <area>Transport Area</area>
 
@@ -316,20 +316,24 @@
       are also described and defined in <xref target="RFC9197"/>.</t>
 
       <t>As this document describes new options for IPv6, the
-      security considerations of <xref target="RFC8200"/> and the
-      weakness documented in <xref target="RFC8250"/> apply.</t>
+      security considerations of <xref target="RFC8200"/> and 
+      <xref target="RFC8250"/> apply.</t>
 
       <t>From a network-protection perspective, there is an assumed
-      trust model such that any node that adds IOAM to a packet,
-      removes IOAM from a packet, or modifies IOAM data fields 
-      of a packet is assumed to be allowed to do so.  By default, packets that
-      include IPv6 extension headers with IOAM information MUST NOT
-      be leaked through the boundaries of the IOAM-Domain.</t>
-IOAM-domain boundary routers MUST filter any incoming traffic from outside the IOAM-domain that contains IPv6 extension headers with IOAM information. IOAM-domain boundary routers MUST also filter any outgoing traffic leaving the IOAM-domain that contains IPv6 extension headers with IOAM information. 
+        trust model such that any node that adds IOAM to a packet,
+        removes IOAM from a packet, or modifies IOAM data fields 
+        of a packet is assumed to be allowed to do so.  By default, packets that
+        include IPv6 extension headers with IOAM information MUST NOT
+        be leaked through the boundaries of the IOAM-Domain.</t>
+      <t>IOAM-Domain boundary routers MUST filter any incoming traffic
+	from outside the IOAM-Domain that contains IPv6 extension headers
+	with IOAM information. IOAM-Domain boundary routers MUST 
+	also filter any outgoing traffic leaving the IOAM-Domain that 
+        contains IPv6 extension headers with IOAM information.</t>
       <t>In the general case, an IOAM node only adds, removes, or modifies
-      an IPv6 extension header with IOAM information, if the
-      directive to do so comes from a trusted source and the directive
-      is validated.</t>
+        an IPv6 extension header with IOAM information, if the
+        directive to do so comes from a trusted source and the directive
+        is validated.</t>
 
       <t>Problems may occur if the above behaviors are not implemented
       or if the assumed trust model is violated (e.g., through a security

--- a/drafts/draft-ietf-ippm-ioam-ipv6-options.xml
+++ b/drafts/draft-ietf-ippm-ioam-ipv6-options.xml
@@ -325,7 +325,7 @@
       of a packet is assumed to be allowed to do so.  By default, packets that
       include IPv6 extension headers with IOAM information MUST NOT
       be leaked through the boundaries of the IOAM-Domain.</t>
-
+IOAM-domain boundary routers MUST filter any incoming traffic from outside the IOAM-domain that contains IPv6 extension headers with IOAM information. IOAM-domain boundary routers MUST also filter any outgoing traffic leaving the IOAM-domain that contains IPv6 extension headers with IOAM information. 
       <t>In the general case, an IOAM node only adds, removes, or modifies
       an IPv6 extension header with IOAM information, if the
       directive to do so comes from a trusted source and the directive

--- a/drafts/draft-ietf-ippm-ioam-ipv6-options.xml
+++ b/drafts/draft-ietf-ippm-ioam-ipv6-options.xml
@@ -13,17 +13,17 @@
 <!ENTITY RFC4193 SYSTEM "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.4193.xml">
 <!ENTITY RFC1772 SYSTEM "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.1772.xml">
 <!ENTITY RFC9197 SYSTEM "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.9197.xml">
-<!ENTITY RFC8799 SYSTEM "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.8799.xml">
 <!ENTITY RFC4302 SYSTEM "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.4302.xml">
+<!ENTITY RFC9098 SYSTEM "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.9098.xml">
+<!ENTITY RFC9326 SYSTEM "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.9326.xml">
 
-<!ENTITY I-D.ietf-ippm-ioam-direct-export SYSTEM "http://xml2rfc.tools.ietf.org/public/rfc/bibxml-ids/reference.I-D.ietf-ippm-ioam-direct-export.xml">
 ]>
 <?rfc toc="yes"?>
 <?rfc tocompact="no"?>
 <?rfc tocdepth="3"?>
 <?rfc symrefs="yes"?>
 <?rfc sortrefs="yes"?>
-<rfc category="std" docName="draft-ietf-ippm-ioam-ipv6-options-10"
+<rfc category="std" docName="draft-ietf-ippm-ioam-ipv6-options-11"
      ipr="trust200902">
   <front>
     <title abbrev="In-situ OAM IPv6 encapsulation">In-situ OAM IPv6
@@ -52,8 +52,6 @@
 
           <city>DUESSELDORF</city>
 
-          <region>NORDRHEIN-WESTFALEN</region>
-
           <code>40549</code>
 
           <country>Germany</country>
@@ -67,7 +65,7 @@
 
 
 
-    <date day="24" month="February" year="2023"/>
+    <date day="21" month="April" year="2023"/>
 
     <area>Transport Area</area>
 
@@ -87,8 +85,7 @@
       operational and telemetry information in the packet while the packet
       traverses a path between two points in the network. IOAM concepts 
       and associated nomenclature, as well as IOAM data fields are
-      defined in <xref target="RFC9197"/>. IOAM is a functionality that
-      applies to limited domains <xref target="RFC8799"/>. 
+      defined in <xref target="RFC9197"/>. 
       This document outlines how IOAM data fields are encapsulated in IPv6 <xref
       target="RFC8200"/> and discusses deployment requirements for networks that
       use IPv6-encapsulated IOAM data fields.</t>
@@ -215,7 +212,7 @@
             </list></t>
 
           <t>Direct Export (DEX) Option: The IOAM Direct Export Option-Type defined in
-          Section 3.2 of <xref target="I-D.ietf-ippm-ioam-direct-export"/> is represented
+          Section 3.2 of <xref target="RFC9326"/> is represented
           as an IPv6 option in the hop-by-hop extension header:
           <list style="hanging">
               <t hangText="Option Type:">TBD_1_0 8-bit identifier of the
@@ -244,8 +241,17 @@
 
         <t>IOAM deployments in IPv6 networks MUST take the following
         considerations and requirements into account:<list style="hanging">
-            <t hangText="C1">IOAM MUST be deployed as a limited domain feature
-            as defined in <xref target="RFC8799"/>. </t>
+            <t hangText="C1">
+            IOAM MUST be deployed in an IOAM-Domain. An IOAM-Domain
+            is a set of nodes that use IOAM. An IOAM-Domain is bounded by
+            its perimeter or edge. The set of nodes forming an IOAM-Domain
+            may be connected to the same physical infrastructure
+            (e.g., a service provider's network). They may also be remotely
+            connected to each other (e.g., an enterprise VPN or an overlay).
+            It is expected that all nodes in an IOAM-Domain are managed by
+            the same administrative entity. Please refer to
+            <xref target="RFC9197"/>) for more details on IOAM-Domains.
+	    </t>
             <t hangText="C2">Implementations of IOAM MUST ensure that the
             addition of IOAM data fields does not alter the way routers
             forward packets or the forwarding decisions they make.
@@ -270,9 +276,7 @@
             the packet being dropped.
             The PMTU tolerance range must be identified and IOAM encapsulation
             operations or data field insertion must not exceed this range.
-            Control of the MTU is critical to the proper operation of IOAM and
-            is one of the reasons it is considered a limited domain feature
-            (see also <xref target="RFC8799"/>).
+            Control of the MTU is critical to the proper operation of IOAM.
             The PMTU tolerance must be identified through configuration and
             IOAM operations must not exceed the packet size beyond PMTU.</t>
 
@@ -306,22 +310,41 @@
 
     <section title="Security Considerations">
       <t>This document describes the encapsulation of IOAM data fields in
-      IPv6. Security considerations of the specific IOAM data fields for each
-      case (i.e., Trace, Proof of Transit, and E2E) are described and defined
-      in <xref target="RFC9197"/>.</t>
+      IPv6. For general IOAM security considerations,
+      see <xref target="RFC9197"/>. Security considerations of the specific
+      IOAM data fields for each case (i.e., Trace, Proof of Transit, and E2E)
+      are also described and defined in <xref target="RFC9197"/>.</t>
 
-      <t>As this document describes new options for IPv6, these are similar to
-      the security considerations of <xref target="RFC8200"/> and the
-      weakness documented in <xref target="RFC8250"/>.</t>
+      <t>As this document describes new options for IPv6, the
+      security considerations of <xref target="RFC8200"/> and the
+      weakness documented in <xref target="RFC8250"/> apply.</t>
+
+      <t>From a network-protection perspective, there is an assumed
+      trust model such that any node that adds IOAM to a packet,
+      removes IOAM from a packet, or modifies IOAM data fields 
+      of a packet is assumed to be allowed to do so.  By default, packets that
+      include IPv6 extension headers with IOAM information MUST NOT
+      be leaked through the boundaries of the IOAM-Domain.</t>
+
+      <t>In the general case, an IOAM node only adds, removes, or modifies
+      an IPv6 extension header with IOAM information, if the
+      directive to do so comes from a trusted source and the directive
+      is validated.</t>
+
+      <t>Problems may occur if the above behaviors are not implemented
+      or if the assumed trust model is violated (e.g., through a security
+      breach). In addition to the security considerations discussed in
+      <xref target="RFC9197"/>, the security considerations associated
+      with IPv6 extension headers listed in <xref target="RFC9098"/> apply.</t>
 
      <section title="Applicability of AH">
-      <t> IOAM is a limited domain feature (refer to <xref target="RFC8799"/>).
-      The network devices in an IOAM domain are trusted to add, update and remove
+      <t> 
+      The network devices in an IOAM-Domain are trusted to add, update and remove
       IOAM options according to the constraints specified in <xref target="RFC8200"/>.
       IOAM domain does not rely on the Authentication Header (AH) as defined in
       <xref target="RFC4302"/> to secure IOAM options.
       The use of IOAM options with AH and its processing is not defined
-      in this document. Future documents may define use of IOAM with AH and
+      in this document. Future documents may define the use of IOAM with AH and
       its processing.</t>
      </section>
 
@@ -376,7 +399,7 @@
 
       &RFC9197;
 
-      &I-D.ietf-ippm-ioam-direct-export;
+      &RFC9326;
 
     </references>
 
@@ -387,7 +410,7 @@
 
       &RFC4302;
 
-      &RFC8799;
+      &RFC9098;
 
       <reference anchor="I-D.kitamura-ipv6-record-route">
         <front>

--- a/drafts/versions/11/draft-ietf-ippm-ioam-ipv6-options-11.txt
+++ b/drafts/versions/11/draft-ietf-ippm-ioam-ipv6-options-11.txt
@@ -1,0 +1,672 @@
+
+
+
+
+ippm                                                    S. Bhandari, Ed.
+Internet-Draft                                               Thoughtspot
+Intended status: Standards Track                       F. Brockners, Ed.
+Expires: 23 October 2023                                           Cisco
+                                                           21 April 2023
+
+
+                        In-situ OAM IPv6 Options
+                  draft-ietf-ippm-ioam-ipv6-options-11
+
+Abstract
+
+   In-situ Operations, Administration, and Maintenance (IOAM) records
+   operational and telemetry information in the packet while the packet
+   traverses a path between two points in the network.  This document
+   outlines how IOAM data fields are encapsulated in IPv6.
+
+Status of This Memo
+
+   This Internet-Draft is submitted in full conformance with the
+   provisions of BCP 78 and BCP 79.
+
+   Internet-Drafts are working documents of the Internet Engineering
+   Task Force (IETF).  Note that other groups may also distribute
+   working documents as Internet-Drafts.  The list of current Internet-
+   Drafts is at https://datatracker.ietf.org/drafts/current/.
+
+   Internet-Drafts are draft documents valid for a maximum of six months
+   and may be updated, replaced, or obsoleted by other documents at any
+   time.  It is inappropriate to use Internet-Drafts as reference
+   material or to cite them other than as "work in progress."
+
+   This Internet-Draft will expire on 23 October 2023.
+
+Copyright Notice
+
+   Copyright (c) 2023 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents (https://trustee.ietf.org/
+   license-info) in effect on the date of publication of this document.
+   Please review these documents carefully, as they describe your rights
+   and restrictions with respect to this document.  Code Components
+   extracted from this document must include Revised BSD License text as
+   described in Section 4.e of the Trust Legal Provisions and are
+   provided without warranty as described in the Revised BSD License.
+
+
+
+
+Bhandari & Brockners     Expires 23 October 2023                [Page 1]
+
+Internet-Draft       In-situ OAM IPv6 encapsulation           April 2023
+
+
+Table of Contents
+
+   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   2
+   2.  Conventions . . . . . . . . . . . . . . . . . . . . . . . . .   2
+     2.1.  Requirements Language . . . . . . . . . . . . . . . . . .   2
+     2.2.  Abbreviations . . . . . . . . . . . . . . . . . . . . . .   2
+   3.  In-situ OAM Metadata Transport in IPv6  . . . . . . . . . . .   3
+   4.  IOAM Deployment In IPv6 Networks  . . . . . . . . . . . . . .   5
+     4.1.  Considerations for IOAM deployment and implementation in
+           IPv6 networks . . . . . . . . . . . . . . . . . . . . . .   5
+     4.2.  IOAM domains bounded by hosts . . . . . . . . . . . . . .   6
+     4.3.  IOAM domains bounded by network devices . . . . . . . . .   6
+   5.  Security Considerations . . . . . . . . . . . . . . . . . . .   7
+     5.1.  Applicability of AH . . . . . . . . . . . . . . . . . . .   7
+   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   7
+   7.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .   8
+   8.  References  . . . . . . . . . . . . . . . . . . . . . . . . .   8
+     8.1.  Normative References  . . . . . . . . . . . . . . . . . .   8
+     8.2.  Informative References  . . . . . . . . . . . . . . . . .   9
+   Contributors  . . . . . . . . . . . . . . . . . . . . . . . . . .   9
+   Contributors' Addresses . . . . . . . . . . . . . . . . . . . . .  10
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  11
+
+1.  Introduction
+
+   In-situ Operations, Administration, and Maintenance (IOAM) records
+   operational and telemetry information in the packet while the packet
+   traverses a path between two points in the network.  IOAM concepts
+   and associated nomenclature, as well as IOAM data fields are defined
+   in [RFC9197].  This document outlines how IOAM data fields are
+   encapsulated in IPv6 [RFC8200] and discusses deployment requirements
+   for networks that use IPv6-encapsulated IOAM data fields.
+
+2.  Conventions
+
+2.1.  Requirements Language
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and
+   "OPTIONAL" in this document are to be interpreted as described in BCP
+   14 [RFC2119] [RFC8174] when, and only when, they appear in all
+   capitals, as shown here.
+
+2.2.  Abbreviations
+
+   Abbreviations used in this document:
+
+   E2E:       Edge-to-Edge
+
+
+
+Bhandari & Brockners     Expires 23 October 2023                [Page 2]
+
+Internet-Draft       In-situ OAM IPv6 encapsulation           April 2023
+
+
+   IOAM:      In-situ Operations, Administration, and Maintenance as
+              defined in [RFC9197]
+
+   OAM:       Operations, Administration, and Maintenance
+
+   POT:       Proof of Transit
+
+3.  In-situ OAM Metadata Transport in IPv6
+
+   IOAM in IPv6 is used to enhance diagnostics of IPv6 networks.  It
+   complements other mechanisms designed to enhance diagnostics of IPv6
+   networks, such as the IPv6 Performance and Diagnostic Metrics
+   Destination Option described in [RFC8250].
+
+   At the time this document was written, several implementations of
+   IOAM for IPv6 exist, e.g., IOAM for IPv6 in the Linux Kernel
+   (supported from Kernel version 5.15 onwards IPv6 IOAM in Linux Kernel
+   (https://github.com/torvalds/linux/
+   commit/7c804e91df523a37c29e183ea2b10ac73c3a4f3d)), IOAM for IPv6 in
+   VPP (https://docs.fd.io/vpp/17.04/ioam_ipv6_doc.html).
+
+   IOAM data fields can be encapsulated with two types of extension
+   headers in IPv6 packets - either the hop-by-hop options header or the
+   destination options header.  Multiple options with the same option
+   type MAY appear in the same hop-by-hop options or destination options
+   header, with distinct content.
+
+   An IPv6 packet carrying IOAM data in an extension header can have
+   other extension headers, compliant with [RFC8200].
+
+   IPv6 hop-by-hop and destination option format for carrying IOAM data
+   fields:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Bhandari & Brockners     Expires 23 October 2023                [Page 3]
+
+Internet-Draft       In-situ OAM IPv6 encapsulation           April 2023
+
+
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |  Option Type  |  Opt Data Len |   Reserved    |   IOAM Type   |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+<-+
+   |                                                               |  |
+   .                                                               .  I
+   .                                                               .  O
+   .                                                               .  A
+   .                                                               .  M
+   .                                                               .  .
+   .                          Option Data                          .  O
+   .                                                               .  P
+   .                                                               .  T
+   .                                                               .  I
+   .                                                               .  O
+   .                                                               .  N
+   |                                                               |  |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+<-+
+
+   Option Type:  8-bit option type identifier as defined in Section 6.
+
+   Opt Data Len:  8-bit unsigned integer.  Length of this option, in
+      octets, not including the first 2 octets.
+
+   Reserved:  8-bit field MUST be set to zero by the source.
+
+   IOAM Type:  8-bit field as defined in section 7.1 in [RFC9197].
+
+   Option Data:  Variable-length field.  Option-Type-specific data.
+
+   IOAM Option data is inserted as follows:
+
+   1.  Pre-allocated Trace Option: The IOAM Preallocated Trace Option-
+       Type defined in Section 4.4 of [RFC9197] is represented as an
+       IPv6 option in the hop-by-hop extension header:
+
+       Option Type:  TBD_1_1 8-bit identifier of the IPv6 Option Type
+          for IOAM.
+
+       IOAM Type:  IOAM Pre-allocated Trace Option-Type.
+
+   2.  Proof of Transit Option: The IOAM POT Option-Type defined in
+       Section 4.5 of [RFC9197] is represented as an IPv6 option in the
+       hop-by-hop extension header:
+
+       Option Type:  TBD_1_1 8-bit identifier of the IPv6 Option Type
+          for IOAM.
+
+       IOAM Type:  IOAM POT Option-Type.
+
+
+
+Bhandari & Brockners     Expires 23 October 2023                [Page 4]
+
+Internet-Draft       In-situ OAM IPv6 encapsulation           April 2023
+
+
+   3.  Edge to Edge Option: The IOAM E2E option defined in Section 4.6
+       [RFC9197] is represented as an IPv6 option in destination
+       extension header:
+
+       Option Type:  TBD_1_0 8-bit identifier of the IPv6 Option Type
+          for IOAM.
+
+       IOAM Type:  IOAM E2E Option-Type.
+
+   4.  Direct Export (DEX) Option: The IOAM Direct Export Option-Type
+       defined in Section 3.2 of [RFC9326] is represented as an IPv6
+       option in the hop-by-hop extension header:
+
+       Option Type:  TBD_1_0 8-bit identifier of the IPv6 Option Type
+          for IOAM.
+
+       IOAM Type:  IOAM Direct Export (DEX) Option-Type.
+
+   All the IOAM IPv6 options defined here have alignment requirements.
+   Specifically, they all require 4n alignment.  This ensures that
+   fields specified in [RFC9197] are aligned at a multiple-of-4 offset
+   from the start of the hop-by-hop and destination options header.
+
+   IPv6 options can have a maximum length of 255 octets.  Consequently,
+   the total length of IOAM Option-Types including all data fields is
+   also limited to 255 octets when encapsulated into IPv6.
+
+4.  IOAM Deployment In IPv6 Networks
+
+
+4.1.  Considerations for IOAM deployment and implementation in IPv6
+      networks
+
+   IOAM deployments in IPv6 networks MUST take the following
+   considerations and requirements into account:
+
+   C1  IOAM MUST be deployed in an IOAM-Domain.  An IOAM-Domain is a set
+      of nodes that use IOAM.  An IOAM-Domain is bounded by its
+      perimeter or edge.  The set of nodes forming an IOAM-Domain may be
+      connected to the same physical infrastructure (e.g., a service
+      provider's network).  They may also be remotely connected to each
+      other (e.g., an enterprise VPN or an overlay).  It is expected
+      that all nodes in an IOAM-Domain are managed by the same
+      administrative entity.  Please refer to [RFC9197]) for more
+      details on IOAM-Domains.
+
+   C2  Implementations of IOAM MUST ensure that the addition of IOAM
+
+
+
+
+Bhandari & Brockners     Expires 23 October 2023                [Page 5]
+
+Internet-Draft       In-situ OAM IPv6 encapsulation           April 2023
+
+
+      data fields does not alter the way routers forward packets or the
+      forwarding decisions they make.  Packets with added IOAM
+      information must follow the same path within the domain as an
+      identical packet without IOAM information would, even in the
+      presence of Equal-Cost Multi-Path (ECMP).  This behavior is
+      important for deployments where IOAM data fields are only added
+      "on-demand".  Implementations of IOAM MUST ensure that ECMP
+      behavior for packets with and without IOAM data fields is the
+      same.  In order for IOAM to work in IPv6 networks, IOAM MUST be
+      explicitly enabled per interface on every node within the IOAM
+      domain.  Unless a particular interface is explicitly enabled
+      (i.e., explicitly configured) for IOAM, a router MUST ignore IOAM
+      Options.
+
+   C3  In order to maintain the integrity of packets in an IOAM domain,
+      the Maximum Transmission Unit (MTU) of transit routers and
+      switches must be configured to a value that does not lead to an
+      ICMP Packet Too Big error message being sent to the originator and
+      the packet being dropped.  The PMTU tolerance range must be
+      identified and IOAM encapsulation operations or data field
+      insertion must not exceed this range.  Control of the MTU is
+      critical to the proper operation of IOAM.  The PMTU tolerance must
+      be identified through configuration and IOAM operations must not
+      exceed the packet size beyond PMTU.
+
+   C4  [RFC8200] precludes insertion of IOAM data directly into the
+      original IPv6 header of in-flight packets.  IOAM deployments which
+      do not encapsulate/decapsulate IOAM on the host but desire to
+      encapsulate/decapsulate IOAM on transit nodes MUST add an
+      additional IPv6 header to the original packet.  IOAM data is added
+      to this additional IPv6 header.
+
+4.2.  IOAM domains bounded by hosts
+
+   For deployments where the IOAM domain is bounded by hosts, hosts will
+   perform the operation of IOAM data field encapsulation and
+   decapsulation.  IOAM data is carried in IPv6 packets as hop-by-hop or
+   destination options as specified in this document.
+
+4.3.  IOAM domains bounded by network devices
+
+   For deployments where the IOAM domain is bounded by network devices,
+   network devices such as routers form the edge of an IOAM domain.
+   Network devices will perform the operation of IOAM data field
+   encapsulation and decapsulation.
+
+
+
+
+
+
+Bhandari & Brockners     Expires 23 October 2023                [Page 6]
+
+Internet-Draft       In-situ OAM IPv6 encapsulation           April 2023
+
+
+5.  Security Considerations
+
+   This document describes the encapsulation of IOAM data fields in
+   IPv6.  For general IOAM security considerations, see [RFC9197].
+   Security considerations of the specific IOAM data fields for each
+   case (i.e., Trace, Proof of Transit, and E2E) are also described and
+   defined in [RFC9197].
+
+   As this document describes new options for IPv6, the security
+   considerations of [RFC8200] and the weakness documented in [RFC8250]
+   apply.
+
+   From a network-protection perspective, there is an assumed trust
+   model such that any node that adds IOAM to a packet, removes IOAM
+   from a packet, or modifies IOAM data fields of a packet is assumed to
+   be allowed to do so.  By default, packets that include IPv6 extension
+   headers with IOAM information MUST NOT be leaked through the
+   boundaries of the IOAM-Domain.
+
+   In the general case, an IOAM node only adds, removes, or modifies an
+   IPv6 extension header with IOAM information, if the directive to do
+   so comes from a trusted source and the directive is validated.
+
+   Problems may occur if the above behaviors are not implemented or if
+   the assumed trust model is violated (e.g., through a security
+   breach).  In addition to the security considerations discussed in
+   [RFC9197], the security considerations associated with IPv6 extension
+   headers listed in [RFC9098] apply.
+
+5.1.  Applicability of AH
+
+   The network devices in an IOAM-Domain are trusted to add, update and
+   remove IOAM options according to the constraints specified in
+   [RFC8200].  IOAM domain does not rely on the Authentication Header
+   (AH) as defined in [RFC4302] to secure IOAM options.  The use of IOAM
+   options with AH and its processing is not defined in this document.
+   Future documents may define the use of IOAM with AH and its
+   processing.
+
+6.  IANA Considerations
+
+   This draft requests the following IPv6 Option Type assignments from
+   the destination options and hop-by-hop options sub-registry of
+   Internet Protocol Version 6 (IPv6) Parameters.
+
+   http://www.iana.org/assignments/ipv6-parameters/ipv6-
+   parameters.xhtml#ipv6-parameters-2
+
+
+
+
+Bhandari & Brockners     Expires 23 October 2023                [Page 7]
+
+Internet-Draft       In-situ OAM IPv6 encapsulation           April 2023
+
+
+      Hex Value    Binary Value      Description            Reference
+                   act chg rest
+      ------------------------------------------------------------------
+      TBD_1_0      00   0  TBD_1     IOAM                   [This draft]
+                                     destination option
+                                     and
+                                     IOAM hop-by-hop option
+      TBD_1_1      00   1  TBD_1     IOAM                   [This draft]
+                                     destination option
+                                     and
+                                     IOAM hop-by-hop option
+
+7.  Acknowledgements
+
+   The authors would like to thank Tom Herbert, Eric Vyncke, Nalini
+   Elkins, Srihari Raghavan, Ranganathan T S, Karthik Babu Harichandra
+   Babu, Akshaya Nadahalli, Stefano Previdi, Hemant Singh, Erik
+   Nordmark, LJ Wobker, Mark Smith, Andrew Yourtchenko and Justin Iurman
+   for the comments and advice.  For the IPv6 encapsulation, this
+   document leverages concepts described in
+   [I-D.kitamura-ipv6-record-route].  The authors would like to
+   acknowledge the work done by the author Hiroshi Kitamura and people
+   involved in writing it.
+
+8.  References
+
+8.1.  Normative References
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119,
+              DOI 10.17487/RFC2119, March 1997,
+              <https://www.rfc-editor.org/info/rfc2119>.
+
+   [RFC8174]  Leiba, B., "Ambiguity of Uppercase vs Lowercase in RFC
+              2119 Key Words", BCP 14, RFC 8174, DOI 10.17487/RFC8174,
+              May 2017, <https://www.rfc-editor.org/info/rfc8174>.
+
+   [RFC9197]  Brockners, F., Ed., Bhandari, S., Ed., and T. Mizrahi,
+              Ed., "Data Fields for In Situ Operations, Administration,
+              and Maintenance (IOAM)", RFC 9197, DOI 10.17487/RFC9197,
+              May 2022, <https://www.rfc-editor.org/info/rfc9197>.
+
+   [RFC9326]  Song, H., Gafni, B., Brockners, F., Bhandari, S., and T.
+              Mizrahi, "In Situ Operations, Administration, and
+              Maintenance (IOAM) Direct Exporting", RFC 9326,
+              DOI 10.17487/RFC9326, November 2022,
+              <https://www.rfc-editor.org/info/rfc9326>.
+
+
+
+
+Bhandari & Brockners     Expires 23 October 2023                [Page 8]
+
+Internet-Draft       In-situ OAM IPv6 encapsulation           April 2023
+
+
+8.2.  Informative References
+
+   [I-D.kitamura-ipv6-record-route]
+              Kitamura, H., "Record Route for IPv6 (PR6) Hop-by-Hop
+              Option Extension", Work in Progress, Internet-Draft,
+              draft-kitamura-ipv6-record-route-00, November 2000,
+              <https://tools.ietf.org/id/draft-kitamura-ipv6-record-
+              route-00.txt>.
+
+   [RFC4302]  Kent, S., "IP Authentication Header", RFC 4302,
+              DOI 10.17487/RFC4302, December 2005,
+              <https://www.rfc-editor.org/info/rfc4302>.
+
+   [RFC8200]  Deering, S. and R. Hinden, "Internet Protocol, Version 6
+              (IPv6) Specification", STD 86, RFC 8200,
+              DOI 10.17487/RFC8200, July 2017,
+              <https://www.rfc-editor.org/info/rfc8200>.
+
+   [RFC8250]  Elkins, N., Hamilton, R., and M. Ackermann, "IPv6
+              Performance and Diagnostic Metrics (PDM) Destination
+              Option", RFC 8250, DOI 10.17487/RFC8250, September 2017,
+              <https://www.rfc-editor.org/info/rfc8250>.
+
+   [RFC9098]  Gont, F., Hilliard, N., Doering, G., Kumari, W., Huston,
+              G., and W. Liu, "Operational Implications of IPv6 Packets
+              with Extension Headers", RFC 9098, DOI 10.17487/RFC9098,
+              September 2021, <https://www.rfc-editor.org/info/rfc9098>.
+
+Contributors
+
+   This document was the collective effort of several authors.  The text
+   and content were contributed by the editors and the co-authors listed
+   below.  The contact information of the co-authors appears at the end
+   of this document.
+
+   *  Carlos Pignataro
+
+   *  Hannes Gredler
+
+   *  John Leddy
+
+   *  Stephen Youell
+
+   *  Tal Mizrahi
+
+   *  Aviv Kfir
+
+   *  Barak Gafni
+
+
+
+Bhandari & Brockners     Expires 23 October 2023                [Page 9]
+
+Internet-Draft       In-situ OAM IPv6 encapsulation           April 2023
+
+
+   *  Petr Lapukhov
+
+   *  Mickey Spiegel
+
+   *  Suresh Krishnan
+
+   *  Rajiv Asati
+
+   *  Mark Smith
+
+Contributors' Addresses
+
+      Carlos Pignataro
+      Cisco Systems, Inc.
+      7200-11 Kit Creek Road
+      Research Triangle Park, NC  27709
+      United States
+      Email: cpignata@cisco.com
+
+
+      Hannes Gredler
+      RtBrick Inc.
+      Email: hannes@rtbrick.com
+
+
+      John Leddy
+      Email: john@leddy.net
+
+
+      Stephen Youell
+      JP Morgan Chase
+      25 Bank Street
+      London  E14 5JP
+      United Kingdom
+      Email: stephen.youell@jpmorgan.com
+
+
+      Tal Mizrahi
+      Huawei Network.IO Innovation Lab
+      Israel
+      Email: tal.mizrahi.phd@gmail.com
+
+
+      Aviv Kfir
+      Mellanox Technologies, Inc.
+      350 Oakmead Parkway, Suite 100
+      Sunnyvale, CA  94085
+      U.S.A.
+
+
+
+Bhandari & Brockners     Expires 23 October 2023               [Page 10]
+
+Internet-Draft       In-situ OAM IPv6 encapsulation           April 2023
+
+
+      Email: avivk@mellanox.com
+
+
+      Barak Gafni
+      Mellanox Technologies, Inc.
+      350 Oakmead Parkway, Suite 100
+      Sunnyvale, CA  94085
+      U.S.A.
+      Email: gbarak@mellanox.com
+
+
+      Petr Lapukhov
+      Facebook
+      1 Hacker Way
+      Menlo Park, CA  94025
+      US
+      Email: petr@fb.com
+
+
+      Mickey Spiegel
+      Barefoot Networks, an Intel company
+      4750 Patrick Henry Drive
+      Santa Clara, CA  95054
+      US
+      Email: mickey.spiegel@intel.com
+
+
+      Suresh Krishnan
+      Kaloom
+      Email: suresh@kaloom.com
+
+      Rajiv Asati
+      Cisco Systems, Inc.
+      7200 Kit Creek Road
+      Research Triangle Park, NC  27709
+      US
+      Email: rajiva@cisco.com
+
+
+      Mark Smith
+      PO BOX 521
+      HEIDELBERG, VIC  3084
+      AU
+      Email: markzzzsmith+id@gmail.com
+
+Authors' Addresses
+
+
+
+
+
+Bhandari & Brockners     Expires 23 October 2023               [Page 11]
+
+Internet-Draft       In-situ OAM IPv6 encapsulation           April 2023
+
+
+   Shwetha Bhandari (editor)
+   Thoughtspot
+   3rd Floor, Indiqube Orion, 24th Main Rd, Garden Layout, HSR Layout
+   Bangalore, KARNATAKA 560 102
+   India
+   Email: shwetha.bhandari@thoughtspot.com
+
+
+   Frank Brockners (editor)
+   Cisco Systems, Inc.
+   Hansaallee 249, 3rd Floor
+   40549 DUESSELDORF
+   Germany
+   Email: fbrockne@cisco.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Bhandari & Brockners     Expires 23 October 2023               [Page 12]

--- a/drafts/versions/11/draft-ietf-ippm-ioam-ipv6-options-11.txt
+++ b/drafts/versions/11/draft-ietf-ippm-ioam-ipv6-options-11.txt
@@ -5,8 +5,8 @@
 ippm                                                    S. Bhandari, Ed.
 Internet-Draft                                               Thoughtspot
 Intended status: Standards Track                       F. Brockners, Ed.
-Expires: 23 October 2023                                           Cisco
-                                                           21 April 2023
+Expires: 5 November 2023                                           Cisco
+                                                              4 May 2023
 
 
                         In-situ OAM IPv6 Options
@@ -34,7 +34,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 23 October 2023.
+   This Internet-Draft will expire on 5 November 2023.
 
 Copyright Notice
 
@@ -53,9 +53,9 @@ Copyright Notice
 
 
 
-Bhandari & Brockners     Expires 23 October 2023                [Page 1]
+Bhandari & Brockners     Expires 5 November 2023                [Page 1]
 
-Internet-Draft       In-situ OAM IPv6 encapsulation           April 2023
+Internet-Draft       In-situ OAM IPv6 encapsulation             May 2023
 
 
 Table of Contents
@@ -72,14 +72,14 @@ Table of Contents
      4.3.  IOAM domains bounded by network devices . . . . . . . . .   6
    5.  Security Considerations . . . . . . . . . . . . . . . . . . .   7
      5.1.  Applicability of AH . . . . . . . . . . . . . . . . . . .   7
-   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   7
+   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   8
    7.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .   8
    8.  References  . . . . . . . . . . . . . . . . . . . . . . . . .   8
      8.1.  Normative References  . . . . . . . . . . . . . . . . . .   8
      8.2.  Informative References  . . . . . . . . . . . . . . . . .   9
    Contributors  . . . . . . . . . . . . . . . . . . . . . . . . . .   9
    Contributors' Addresses . . . . . . . . . . . . . . . . . . . . .  10
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  11
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  12
 
 1.  Introduction
 
@@ -109,9 +109,9 @@ Table of Contents
 
 
 
-Bhandari & Brockners     Expires 23 October 2023                [Page 2]
+Bhandari & Brockners     Expires 5 November 2023                [Page 2]
 
-Internet-Draft       In-situ OAM IPv6 encapsulation           April 2023
+Internet-Draft       In-situ OAM IPv6 encapsulation             May 2023
 
 
    IOAM:      In-situ Operations, Administration, and Maintenance as
@@ -165,9 +165,9 @@ Internet-Draft       In-situ OAM IPv6 encapsulation           April 2023
 
 
 
-Bhandari & Brockners     Expires 23 October 2023                [Page 3]
+Bhandari & Brockners     Expires 5 November 2023                [Page 3]
 
-Internet-Draft       In-situ OAM IPv6 encapsulation           April 2023
+Internet-Draft       In-situ OAM IPv6 encapsulation             May 2023
 
 
    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -221,9 +221,9 @@ Internet-Draft       In-situ OAM IPv6 encapsulation           April 2023
 
 
 
-Bhandari & Brockners     Expires 23 October 2023                [Page 4]
+Bhandari & Brockners     Expires 5 November 2023                [Page 4]
 
-Internet-Draft       In-situ OAM IPv6 encapsulation           April 2023
+Internet-Draft       In-situ OAM IPv6 encapsulation             May 2023
 
 
    3.  Edge to Edge Option: The IOAM E2E option defined in Section 4.6
@@ -277,9 +277,9 @@ Internet-Draft       In-situ OAM IPv6 encapsulation           April 2023
 
 
 
-Bhandari & Brockners     Expires 23 October 2023                [Page 5]
+Bhandari & Brockners     Expires 5 November 2023                [Page 5]
 
-Internet-Draft       In-situ OAM IPv6 encapsulation           April 2023
+Internet-Draft       In-situ OAM IPv6 encapsulation             May 2023
 
 
       data fields does not alter the way routers forward packets or the
@@ -333,9 +333,9 @@ Internet-Draft       In-situ OAM IPv6 encapsulation           April 2023
 
 
 
-Bhandari & Brockners     Expires 23 October 2023                [Page 6]
+Bhandari & Brockners     Expires 5 November 2023                [Page 6]
 
-Internet-Draft       In-situ OAM IPv6 encapsulation           April 2023
+Internet-Draft       In-situ OAM IPv6 encapsulation             May 2023
 
 
 5.  Security Considerations
@@ -347,8 +347,7 @@ Internet-Draft       In-situ OAM IPv6 encapsulation           April 2023
    defined in [RFC9197].
 
    As this document describes new options for IPv6, the security
-   considerations of [RFC8200] and the weakness documented in [RFC8250]
-   apply.
+   considerations of [RFC8200] and [RFC8250] apply.
 
    From a network-protection perspective, there is an assumed trust
    model such that any node that adds IOAM to a packet, removes IOAM
@@ -356,6 +355,12 @@ Internet-Draft       In-situ OAM IPv6 encapsulation           April 2023
    be allowed to do so.  By default, packets that include IPv6 extension
    headers with IOAM information MUST NOT be leaked through the
    boundaries of the IOAM-Domain.
+
+   IOAM-Domain boundary routers MUST filter any incoming traffic from
+   outside the IOAM-Domain that contains IPv6 extension headers with
+   IOAM information.  IOAM-Domain boundary routers MUST also filter any
+   outgoing traffic leaving the IOAM-Domain that contains IPv6 extension
+   headers with IOAM information.
 
    In the general case, an IOAM node only adds, removes, or modifies an
    IPv6 extension header with IOAM information, if the directive to do
@@ -377,6 +382,18 @@ Internet-Draft       In-situ OAM IPv6 encapsulation           April 2023
    Future documents may define the use of IOAM with AH and its
    processing.
 
+
+
+
+
+
+
+
+Bhandari & Brockners     Expires 5 November 2023                [Page 7]
+
+Internet-Draft       In-situ OAM IPv6 encapsulation             May 2023
+
+
 6.  IANA Considerations
 
    This draft requests the following IPv6 Option Type assignments from
@@ -385,14 +402,6 @@ Internet-Draft       In-situ OAM IPv6 encapsulation           April 2023
 
    http://www.iana.org/assignments/ipv6-parameters/ipv6-
    parameters.xhtml#ipv6-parameters-2
-
-
-
-
-Bhandari & Brockners     Expires 23 October 2023                [Page 7]
-
-Internet-Draft       In-situ OAM IPv6 encapsulation           April 2023
-
 
       Hex Value    Binary Value      Description            Reference
                    act chg rest
@@ -431,6 +440,16 @@ Internet-Draft       In-situ OAM IPv6 encapsulation           April 2023
               2119 Key Words", BCP 14, RFC 8174, DOI 10.17487/RFC8174,
               May 2017, <https://www.rfc-editor.org/info/rfc8174>.
 
+
+
+
+
+
+Bhandari & Brockners     Expires 5 November 2023                [Page 8]
+
+Internet-Draft       In-situ OAM IPv6 encapsulation             May 2023
+
+
    [RFC9197]  Brockners, F., Ed., Bhandari, S., Ed., and T. Mizrahi,
               Ed., "Data Fields for In Situ Operations, Administration,
               and Maintenance (IOAM)", RFC 9197, DOI 10.17487/RFC9197,
@@ -441,14 +460,6 @@ Internet-Draft       In-situ OAM IPv6 encapsulation           April 2023
               Maintenance (IOAM) Direct Exporting", RFC 9326,
               DOI 10.17487/RFC9326, November 2022,
               <https://www.rfc-editor.org/info/rfc9326>.
-
-
-
-
-Bhandari & Brockners     Expires 23 October 2023                [Page 8]
-
-Internet-Draft       In-situ OAM IPv6 encapsulation           April 2023
-
 
 8.2.  Informative References
 
@@ -487,6 +498,14 @@ Contributors
 
    *  Carlos Pignataro
 
+
+
+
+Bhandari & Brockners     Expires 5 November 2023                [Page 9]
+
+Internet-Draft       In-situ OAM IPv6 encapsulation             May 2023
+
+
    *  Hannes Gredler
 
    *  John Leddy
@@ -498,13 +517,6 @@ Contributors
    *  Aviv Kfir
 
    *  Barak Gafni
-
-
-
-Bhandari & Brockners     Expires 23 October 2023                [Page 9]
-
-Internet-Draft       In-situ OAM IPv6 encapsulation           April 2023
-
 
    *  Petr Lapukhov
 
@@ -543,6 +555,13 @@ Contributors' Addresses
       Email: stephen.youell@jpmorgan.com
 
 
+
+
+Bhandari & Brockners     Expires 5 November 2023               [Page 10]
+
+Internet-Draft       In-situ OAM IPv6 encapsulation             May 2023
+
+
       Tal Mizrahi
       Huawei Network.IO Innovation Lab
       Israel
@@ -554,14 +573,6 @@ Contributors' Addresses
       350 Oakmead Parkway, Suite 100
       Sunnyvale, CA  94085
       U.S.A.
-
-
-
-Bhandari & Brockners     Expires 23 October 2023               [Page 10]
-
-Internet-Draft       In-situ OAM IPv6 encapsulation           April 2023
-
-
       Email: avivk@mellanox.com
 
 
@@ -601,6 +612,12 @@ Internet-Draft       In-situ OAM IPv6 encapsulation           April 2023
       Email: rajiva@cisco.com
 
 
+
+Bhandari & Brockners     Expires 5 November 2023               [Page 11]
+
+Internet-Draft       In-situ OAM IPv6 encapsulation             May 2023
+
+
       Mark Smith
       PO BOX 521
       HEIDELBERG, VIC  3084
@@ -608,15 +625,6 @@ Internet-Draft       In-situ OAM IPv6 encapsulation           April 2023
       Email: markzzzsmith+id@gmail.com
 
 Authors' Addresses
-
-
-
-
-
-Bhandari & Brockners     Expires 23 October 2023               [Page 11]
-
-Internet-Draft       In-situ OAM IPv6 encapsulation           April 2023
-
 
    Shwetha Bhandari (editor)
    Thoughtspot
@@ -661,12 +669,4 @@ Internet-Draft       In-situ OAM IPv6 encapsulation           April 2023
 
 
 
-
-
-
-
-
-
-
-
-Bhandari & Brockners     Expires 23 October 2023               [Page 12]
+Bhandari & Brockners     Expires 5 November 2023               [Page 12]


### PR DESCRIPTION
Version 11 of the draft.
Reference "IOAM-Domains" instead using "limited domains" and a reference to RFC8799.
Detail security considerations wrt/ IOAM-Domains and IPv6.